### PR TITLE
Deploy to Netlify

### DIFF
--- a/.netlify.toml
+++ b/.netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
Heroky deployments are awfully slow (minutes) compared to minutes.

For now we will deploy to both places.

The .netlify.toml changes are to enforce all routing to go to the root
to support react-router's dynamic routing.