### PR TITLE
Upgrade to version 2.0.1 of perf-goggles

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@fortawesome/fontawesome-free-solid": "^5.0.8",
     "@fortawesome/react-fontawesome": "^0.0.17",
     "@material-ui/core": "^1.3.1",
-    "@mozilla-frontend-infra/perf-goggles": "^2.0.0",
+    "@mozilla-frontend-infra/perf-goggles": "^2.0.1",
     "aggregatejs": "^0.0.5",
     "chart.js": "^2.7.2",
     "classnames": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,9 +139,9 @@
     scroll "^2.0.3"
     warning "^4.0.1"
 
-"@mozilla-frontend-infra/perf-goggles@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@mozilla-frontend-infra/perf-goggles/-/perf-goggles-2.0.0.tgz#96484488e9490b31797dc5838a2642534420acd3"
+"@mozilla-frontend-infra/perf-goggles@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@mozilla-frontend-infra/perf-goggles/-/perf-goggles-2.0.1.tgz#514bb39128beb07e29882849607d0efa90284fb8"
   dependencies:
     isomorphic-fetch "^2.2.1"
     lodash.isequal "^4.5.0"


### PR DESCRIPTION
There was an issue in the publishing of the previous version.