### PR TITLE
Add MotoG5 Unity & title/subtitles to Android health page

### DIFF
--- a/src/components/Section/index.jsx
+++ b/src/components/Section/index.jsx
@@ -3,16 +3,17 @@ import PropTypes from 'prop-types';
 import SectionHeader from '../SectionHeader';
 import SectionContent from '../SectionContent';
 
-const Section = ({ title, children }) => (
+const Section = ({ children, subtitle, title }) => (
   <div>
-    <SectionHeader title={title} />
+    <SectionHeader title={title} subtitle={subtitle} />
     <SectionContent>{children}</SectionContent>
   </div>
 );
 
 Section.propTypes = {
-    title: PropTypes.string.isRequired,
     children: PropTypes.shape({}).isRequired,
+    subtitle: PropTypes.string,
+    title: PropTypes.string.isRequired,
 };
 
 export default Section;

--- a/src/components/SectionHeader/index.jsx
+++ b/src/components/SectionHeader/index.jsx
@@ -4,19 +4,29 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = () => ({
   root: {
-    color: '#d1d2d3',
-    fontWeight: '300',
+    color: 'white',
+    fontWeight: '400',
     margin: '.5rem .75rem .5rem',
+  },
+  subtitle: {
+    color: '#d1d2d3',
+    fontSize: '0.75rem',
+    fontWeight: '300',
+    paddingLeft: '.9em',
   },
 });
 
-const SectionHeader = ({ classes, title }) => (
-  <h2 className={classes.root}>{title}</h2>
+const SectionHeader = ({ classes, title, subtitle }) => (
+  <h2 className={classes.root}>
+    {title}
+    {subtitle && <span className={classes.subtitle}>{subtitle}</span>}
+  </h2>
 );
 
 SectionHeader.propTypes = {
   classes: PropTypes.shape({}),
   title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
 };
 
 export default withStyles(styles)(SectionHeader);

--- a/src/containers/PerfherderGraphContainer/index.jsx
+++ b/src/containers/PerfherderGraphContainer/index.jsx
@@ -36,10 +36,13 @@ class PerfherderGraphContainer extends Component {
             return null;
         }
         return (
-          <PerfherderGraph
-            data={data}
-            options={options}
-          />
+          <div>
+            {this.props.title && <h2>{this.props.title}</h2>}
+            <PerfherderGraph
+              data={data}
+              options={options}
+            />
+          </div>
         );
     }
 }
@@ -54,6 +57,7 @@ PerfherderGraphContainer.propTypes = {
         project: PropTypes.string.isRequired,
         suite: PropTypes.string.isRequired,
     })),
+    title: PropTypes.string,
     timeRange: PropTypes.string,
 };
 

--- a/src/views/Android/index.jsx
+++ b/src/views/Android/index.jsx
@@ -80,6 +80,15 @@ class Android extends Component {
           <PerfherderGraphContainer
             series={[
               {
+                color: '#e55525',
+                label: 'Moto G5',
+                frameworkId: 10,
+                platform: 'android-hw-g5-7-0-arm7-api-16',
+                option: 'opt',
+                project: 'mozilla-central',
+                suite: 'raptor-unity-webgl-geckoview',
+              },
+              {
                 color: '#45a1ff',
                 label: 'Pixel 2 (arm7)',
                 frameworkId: 10,

--- a/src/views/Android/index.jsx
+++ b/src/views/Android/index.jsx
@@ -21,7 +21,7 @@ class Android extends Component {
     return (
       <DashboardPage title='Android' subtitle='Release criteria'>
         {!site && (
-          <Section title='Nimbledroid'>
+          <Section title='Nimbledroid' subtitle='GeckoView vs Chrome Beta'>
             <NimbledroidSitesTable
               products={[
                 'org.mozilla.klar',
@@ -45,8 +45,9 @@ class Android extends Component {
             />
           </Section>
         )}
-        <Section title='Speedometer'>
+        <Section title='Perfherder' subtitle='Lower in the graph is better regardless if it is a score or execution time (read the Y label)'>
           <PerfherderGraphContainer
+            title='Speedometer'
             series={[
               {
                 color: '#e55525',
@@ -78,6 +79,7 @@ class Android extends Component {
             ]}
           />
           <PerfherderGraphContainer
+            title='Unity WebGl'
             series={[
               {
                 color: '#e55525',


### PR DESCRIPTION
MotoG5 was running as a tier-3 jobs, thus, I did not notice it.

This also renames the section from "Speedometer" to "Perfherder" plus adds titles to each graph.