### PR TITLE
Test Nimbledroid containers

### DIFF
--- a/src/containers/NimbledroidSiteDrilldown/index.jsx
+++ b/src/containers/NimbledroidSiteDrilldown/index.jsx
@@ -6,28 +6,40 @@ import StatusWidget from '../../components/StatusWidget';
 import { siteMetrics } from '../../utils/nimbledroid';
 import fetchNimbledroidData from '../../utils/nimbledroid/fetchNimbledroidData';
 
-class SiteDrillDown extends Component {
+class NimbledroidSiteDrilldown extends Component {
   state = {
     profile: null,
   };
 
-  async componentDidMount() {
-    const { handleError, nimbledroidData, configuration } = this.props;
-    const { site, products } = configuration;
+  constructor(props) {
+    super(props);
+    const { configuration, nimbledroidData } = this.props;
+    if (nimbledroidData) {
+      this.state = this.generateData(configuration, nimbledroidData);
+    }
+  }
 
+  async componentDidMount() {
+    const { configuration, handleError } = this.props;
     try {
-      const { scenarios } = nimbledroidData || await fetchNimbledroidData(products);
-      this.setSiteData(scenarios[site], configuration);
+      const nimbledroidData = await fetchNimbledroidData(configuration.products);
+      const data = this.generateData(configuration, nimbledroidData);
+      this.setState(data);
     } catch (error) {
       handleError(error);
     }
   }
 
-  setSiteData(profile, { baseProduct, compareProduct, targetRatio }) {
-    this.setState({
+  generateData(configuration, nimbledroidData) {
+    const { baseProduct, compareProduct, targetRatio, site } = configuration;
+
+    const { scenarios } = nimbledroidData;
+    const profile = scenarios[site];
+    const generatedData = {
       profile,
       ...siteMetrics(profile[baseProduct], profile[compareProduct], targetRatio),
-    });
+    };
+    return generatedData;
   }
 
   render() {
@@ -58,7 +70,7 @@ class SiteDrillDown extends Component {
   }
 }
 
-SiteDrillDown.propTypes = ({
+NimbledroidSiteDrilldown.propTypes = ({
   nimbledroidData: PropTypes.shape({}),
   configuration: PropTypes.shape({
     baseProduct: PropTypes.string.isRequired,
@@ -69,4 +81,4 @@ SiteDrillDown.propTypes = ({
   }).isRequired,
 });
 
-export default withErrorBoundary(SiteDrillDown);
+export default withErrorBoundary(NimbledroidSiteDrilldown);

--- a/src/containers/NimbledroidSummaryTable/index.jsx
+++ b/src/containers/NimbledroidSummaryTable/index.jsx
@@ -23,22 +23,22 @@ class NimbledroidSummaryTable extends Component {
     showSites: false,
   };
 
-  async componentDidMount() {
-    const { configuration, nimbledroidData, handleError } = this.props;
-    const { products } = configuration;
-
-    try {
-      const data = nimbledroidData || await fetchNimbledroidData(products);
-      this.setTableContents(data, configuration);
-    } catch (error) {
-      handleError(error);
+  constructor(props) {
+    super(props);
+    const { configuration, nimbledroidData } = this.props;
+    if (nimbledroidData) {
+      this.state = generateSitesTableContent(nimbledroidData, configuration);
     }
   }
 
-  setTableContents(nimbledroidData, configuration) {
-    this.setState({
-      ...generateSitesTableContent(nimbledroidData, configuration),
-    });
+  async componentDidMount() {
+    const { configuration, handleError } = this.props;
+    try {
+      const nimbledroidData = await fetchNimbledroidData(configuration.products);
+      this.setState(generateSitesTableContent(nimbledroidData, configuration));
+    } catch (error) {
+      handleError(error);
+    }
   }
 
   render() {
@@ -85,7 +85,7 @@ NimbledroidSummaryTable.propTypes = {
     compareProduct: PropTypes.string.isRequired,
     products: PropTypes.arrayOf(PropTypes.string).isRequired,
     targetRatio: PropTypes.number.isRequired,
-  }),
+  }).isRequired,
 };
 
 export default withErrorBoundary(withStyles(styles)(NimbledroidSummaryTable));

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,7 +6,8 @@ import Home from './home';
 import ReleaseCrashes from './crashes/release';
 import BetaCrashes from './crashes/beta';
 import Status from './status/index';
-import Android from './views/Android';
+import AndroidPage from './views/Android';
+import NimbledroidGraphPage from './views/NimbledroidGraph';
 import Quantum64 from './quantum/index-64bit';
 import Quantum32 from './quantum/index-32bit';
 import QuantumResponsivenessParent from './quantum/responsiveness-parent';
@@ -21,8 +22,8 @@ const NoMatch = () => <div>404</div>;
 const Routes = () => (
   <BrowserRouter>
     <Switch>
-      <Route path='/android/graph' component={Android} />
-      <Route path='/android' component={Android} />
+      <Route path='/android/graph' component={NimbledroidGraphPage} />
+      <Route path='/android' component={AndroidPage} />
       <Route path='/crashes/beta' component={BetaCrashes} />
       <Route path='/crashes' component={ReleaseCrashes} />
       <Route path='/status' component={Status} />

--- a/src/views/Android/index.jsx
+++ b/src/views/Android/index.jsx
@@ -1,22 +1,13 @@
 import React, { Component } from 'react';
-import propTypes from 'prop-types';
 
 import DashboardPage from '../../components/DashboardPage';
 import Section from '../../components/Section';
 import BugzillaUrlContainer from '../../containers/BugzillaUrlContainer';
 import NimbledroidProductVersions from '../../containers/NimbledroidProductVersions';
 import NimbledroidSitesTable from '../../containers/NimbledroidSummaryTable';
-import NimbledroidSiteDrilldown from '../../containers/NimbledroidSiteDrilldown';
 import PerfherderGraphContainer from '../../containers/PerfherderGraphContainer';
 
 class Android extends Component {
-  static propTypes = {
-    site: propTypes.string,
-    location: propTypes.shape({
-      search: propTypes.string,
-    }),
-  };
-
   render() {
     const products = [
       'org.mozilla.klar',
@@ -24,7 +15,6 @@ class Android extends Component {
       'com.chrome.beta',
     ];
     const targetRatio = 1.2;
-    const site = this.props.location.search.replace('?site=', '');
     return (
       <DashboardPage title='Android' subtitle='Release criteria'>
         <Section title='Bugzilla'>
@@ -52,27 +42,14 @@ class Android extends Component {
         </Section>
         <Section title='Nimbledroid' subtitle='GeckoView vs Chrome Beta'>
           <NimbledroidProductVersions products={products} />
-          {!site && (
-            <NimbledroidSitesTable
-              configuration={{
-                baseProduct: 'org.mozilla.focus',
-                compareProduct: 'com.chrome.beta',
-                products: products,
-                targetRatio: targetRatio,
-              }}
-            />
-          )}
-          {site && (
-            <NimbledroidSiteDrilldown
-              configuration={{
-                baseProduct: 'org.mozilla.focus',
-                compareProduct: 'com.chrome.beta',
-                products: products,
-                site: site,
-                targetRatio: targetRatio,
-              }}
-            />
-          )}
+          <NimbledroidSitesTable
+            configuration={{
+              baseProduct: 'org.mozilla.focus',
+              compareProduct: 'com.chrome.beta',
+              products: products,
+              targetRatio: targetRatio,
+            }}
+          />
         </Section>
         <Section title='Perfherder' subtitle='Lower in the graph is better regardless if it is a score or execution time (read the Y label)'>
           <PerfherderGraphContainer

--- a/src/views/NimbledroidGraph/index.jsx
+++ b/src/views/NimbledroidGraph/index.jsx
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import propTypes from 'prop-types';
+
+import DashboardPage from '../../components/DashboardPage';
+import Section from '../../components/Section';
+import NimbledroidProductVersions from '../../containers/NimbledroidProductVersions';
+import NimbledroidSiteDrilldown from '../../containers/NimbledroidSiteDrilldown';
+
+class NimbledroidGraph extends Component {
+  static propTypes = {
+    site: propTypes.string,
+    location: propTypes.shape({
+      search: propTypes.string,
+    }),
+  };
+
+  render() {
+    const products = [
+      'org.mozilla.klar',
+      'org.mozilla.focus',
+      'com.chrome.beta',
+    ];
+    const targetRatio = 1.2;
+    const site = this.props.location.search.replace('?site=', '');
+    return (
+      <DashboardPage title='Android' subtitle='Release criteria'>
+        <Section title='Nimbledroid' subtitle='GeckoView vs Chrome Beta'>
+          <NimbledroidProductVersions products={products} />
+          <NimbledroidSiteDrilldown
+            configuration={{
+            baseProduct: 'org.mozilla.focus',
+            compareProduct: 'com.chrome.beta',
+            products: products,
+            site: site,
+            targetRatio: targetRatio,
+            }}
+          />
+        </Section>
+      </DashboardPage>
+    );
+  }
+}
+
+export default NimbledroidGraph;

--- a/test/containers/NimbledroidSiteDrilldown.test.jsx
+++ b/test/containers/NimbledroidSiteDrilldown.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import NimbledroidSiteDrilldown from '../../src/containers/NimbledroidSummaryTable';
+
+const nimbledroidData = require('../mocks/nimbledroidData.json');
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create((
+      <NimbledroidSiteDrilldown
+        nimbledroidData={nimbledroidData}
+        configuration={{
+          baseProduct: 'org.mozilla.focus',
+          compareProduct: 'com.chrome.beta',
+          products: [
+            'org.mozilla.klar',
+            'org.mozilla.focus',
+            'com.chrome.beta',
+          ],
+          site: 'reddit.com',
+          targetRatio: 1.2,
+        }}
+      />
+    ))
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/test/containers/NimbledroidTableSummary.test.jsx
+++ b/test/containers/NimbledroidTableSummary.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import NimbledroidSummaryTable from '../../src/containers/NimbledroidSummaryTable';
+
+const nimbledroidData = require('../mocks/nimbledroidData.json');
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create((
+      <NimbledroidSummaryTable
+        nimbledroidData={nimbledroidData}
+        configuration={{
+          baseProduct: 'org.mozilla.focus',
+          compareProduct: 'com.chrome.beta',
+          products: [
+            'org.mozilla.klar',
+            'org.mozilla.focus',
+            'com.chrome.beta',
+          ],
+          targetRatio: 1.2,
+        }}
+      />
+    ))
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/test/containers/__snapshots__/NimbledroidSiteDrilldown.test.jsx.snap
+++ b/test/containers/__snapshots__/NimbledroidSiteDrilldown.test.jsx.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="NimbledroidSummaryTable-root-1"
+>
+  <div>
+    <button
+      className="MuiButtonBase-root-29 MuiButton-root-3 MuiButton-text-5 MuiButton-flat-8"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label-4"
+      >
+        Show detailed view
+      </span>
+      <span
+        className="MuiTouchRipple-root-32"
+      />
+    </button>
+    <div
+      className="NimbledroidSummaryTable-summary-2"
+    >
+      <div>
+        <div
+          className="status-widget status-red padded"
+        >
+          <span
+            className=""
+          >
+            GeckoView &gt; 20% slower than Chrome Beta
+          </span>
+          <span>
+            59/76
+          </span>
+        </div>
+      </div>
+      <div>
+        <div
+          className="status-widget status-yellow padded"
+        >
+          <span
+            className=""
+          >
+            GeckoView &gt; 0% and &lt;= 20% slower than Chrome Beta
+          </span>
+          <span>
+            5/76
+          </span>
+        </div>
+      </div>
+      <div>
+        <div
+          className="status-widget status-green padded"
+        >
+          <span
+            className=""
+          >
+            GeckoView &lt;= 0% (i.e. faster than) Chrome Beta
+          </span>
+          <span>
+            12/76
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/test/containers/__snapshots__/NimbledroidTableSummary.test.jsx.snap
+++ b/test/containers/__snapshots__/NimbledroidTableSummary.test.jsx.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="NimbledroidSummaryTable-root-1"
+>
+  <div>
+    <button
+      className="MuiButtonBase-root-29 MuiButton-root-3 MuiButton-text-5 MuiButton-flat-8"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label-4"
+      >
+        Show detailed view
+      </span>
+      <span
+        className="MuiTouchRipple-root-32"
+      />
+    </button>
+    <div
+      className="NimbledroidSummaryTable-summary-2"
+    >
+      <div>
+        <div
+          className="status-widget status-red padded"
+        >
+          <span
+            className=""
+          >
+            GeckoView &gt; 20% slower than Chrome Beta
+          </span>
+          <span>
+            59/76
+          </span>
+        </div>
+      </div>
+      <div>
+        <div
+          className="status-widget status-yellow padded"
+        >
+          <span
+            className=""
+          >
+            GeckoView &gt; 0% and &lt;= 20% slower than Chrome Beta
+          </span>
+          <span>
+            5/76
+          </span>
+        </div>
+      </div>
+      <div>
+        <div
+          className="status-widget status-green padded"
+        >
+          <span
+            className=""
+          >
+            GeckoView &lt;= 0% (i.e. faster than) Chrome Beta
+          </span>
+          <span>
+            12/76
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Perhaps there's a way to use a plugin to not take a snapshot of a component until `componentDidMount` completes, however, this tricks the components to have the data from the get-go.

I also fix the drilldown situation where the whole Android health page would be displayed rather than just a graph.