### PR TITLE
Issue #134 - Nimbledroid URLs with hashtag symbol would fail to plot

### DIFF
--- a/src/utils/BackendClient/NimbledroidApiHandler.js
+++ b/src/utils/BackendClient/NimbledroidApiHandler.js
@@ -51,14 +51,15 @@ const mergeProductsData = (productsData) => {
       };
 
       // eslint-disable-next-line consistent-return
-      Object.keys(scenarios).forEach((scenarioKey) => {
-        const profileInfo = scenarios[scenarioKey];
+      Object.keys(scenarios).forEach((originalKey) => {
+        const profileInfo = scenarios[originalKey];
         if (profileInfo.data.length === 0) {
           return;
         }
         const sortedData = profileInfo.data.sort(sortDataPointsByRecency);
         const lastDataPoint = (sortedData[sortedData.length - 1].value).toFixed(2);
 
+        const scenarioKey = originalKey.split('#')[0];
         // This is the first time we're seing this scenario
         if (!result[scenarioKey]) {
           delete profileInfo.data;


### PR DESCRIPTION
We change the internal data structure to use the first part of the URL
and discard everything after the hashtag symbol.

Example url:
https://www.buzzfeed.com/daves4/the-new-york-times-makes-the-nerdiest-correction-e?utm_term=.tlL2KE08L6#.hwrBglaV2A