### PR TITLE
Issue #204 - Add tp6 page

### DIFF
--- a/src/components/ChartJsWrapper/index.jsx
+++ b/src/components/ChartJsWrapper/index.jsx
@@ -11,9 +11,12 @@ const styles = {
       width: '600px',
       // Do not let it squeeze too much and deform
       minWidth: '400px',
+      background: 'white',
     },
     title: {
-      margin: '0.1rem 0 0 0',
+      color: 'white',
+      backgroundColor: 'black',
+      padding: '.3rem .3rem .3rem .3rem',
     },
 };
 

--- a/src/components/DashboardPage/index.jsx
+++ b/src/components/DashboardPage/index.jsx
@@ -7,18 +7,22 @@ const styles = {
     display: 'flex',
     flex: '1',
     flexDirection: 'column',
+    backgroundColor: 'white',
+    padding: '2rem',
   },
   title: {
     color: 'white',
     backgroundColor: 'black',
     borderBottom: '1px solid #fff',
-    padding: '0.35rem 0 0 1rem',
+    textAlign: 'center',
+    fontWeight: 100,
+    padding: '0.4rem 0 0 0',
   },
   subtitle: {
-      color: '#d1d2d3',
-      fontWeight: '400',
-      margin: '.5rem .6rem .5rem',
-      padding: '.5em 0',
+    color: '#d1d2d3',
+    fontWeight: 400,
+    margin: '.5rem .6rem .5rem',
+    padding: '.5em 0',
   },
 };
 

--- a/src/components/DashboardPage/index.jsx
+++ b/src/components/DashboardPage/index.jsx
@@ -8,15 +8,13 @@ const styles = {
     flex: '1',
     flexDirection: 'column',
     backgroundColor: 'white',
-    padding: '2rem',
   },
   title: {
     color: 'white',
     backgroundColor: 'black',
     borderBottom: '1px solid #fff',
-    textAlign: 'center',
     fontWeight: 100,
-    padding: '0.4rem 0 0 0',
+    padding: '0.4rem 0 0 1rem',
   },
   subtitle: {
     color: '#d1d2d3',

--- a/src/containers/PerfherderGraphContainer/index.jsx
+++ b/src/containers/PerfherderGraphContainer/index.jsx
@@ -6,14 +6,16 @@ import ChartJsWrapper from '../../components/ChartJsWrapper';
 import getPerferherderData from '../../utils/perfherder/chartJs/getPerfherderData';
 
 const styles = () => ({
-    title: {
-        color: 'black',
-    },
-    linkIcon: {
-        marginLeft: '0.2rem',
-        marginBottom: -5,
-    },
-  });
+  title: {
+    color: 'white',
+    backgroundColor: 'black',
+    padding: '.2rem .3rem .3rem .3rem',
+  },
+  linkIcon: {
+    marginLeft: '0.2rem',
+    marginBottom: -5,
+  },
+});
 
 class PerfherderGraphContainer extends Component {
     state = {
@@ -34,8 +36,8 @@ class PerfherderGraphContainer extends Component {
 
         return (
           <div key={title}>
-            <h2>
-              <span className={classes.title}>{title}</span>
+            <h2 className={classes.title}>
+              <span>{title}</span>
               {jointUrl && (
                 <a href={jointUrl} target='_blank' rel='noopener noreferrer'>
                   <LinkIcon className={classes.linkIcon} />

--- a/src/quantum/config.js
+++ b/src/quantum/config.js
@@ -1,3 +1,7 @@
+import zipObject from 'lodash/zipObject';
+import frum from '../utils/queryOps';
+
+
 const CONFIG = {
   windows64Regression: [
     [
@@ -62,4 +66,87 @@ const CONFIG = {
 
 };
 
-export default CONFIG;
+
+const PLATFORMS = [
+  {
+    browser: 'Firefox',
+    bits: '32',
+    os: 'win',
+    label: 'Firefox',
+    frameworkId: 10,
+    platform: 'windows7-32',
+    option: 'pgo',
+    project: 'mozilla-central',
+  },
+  {
+    browser: 'Firefox',
+    bits: '64',
+    os: 'win',
+    label: 'Firefox',
+    frameworkId: 10,
+    platform: 'windows10-64',
+    option: 'pgo',
+    project: 'mozilla-central',
+  },
+  {
+    browser: 'Chrome',
+    bits: '32',
+    os: 'win',
+    label: 'Chrome',
+    frameworkId: 10,
+    platform: 'windows7-32-nightly',
+    option: 'opt',
+    project: 'mozilla-central',
+  },
+  {
+    browser: 'Chrome',
+    bits: '64',
+    os: 'win',
+    label: 'Chrome',
+    frameworkId: 10,
+    platform: 'windows10-64-nightly',
+    option: 'opt',
+    project: 'mozilla-central',
+  },
+];
+
+const SUITES = {
+  header:
+    ['browser', 'title', 'suite'],
+
+  data: [
+
+    ['Firefox', 'Tp6: Facebook', 'raptor-tp6-facebook-firefox'],
+    ['Firefox', 'Tp6: Amazon', 'raptor-tp6-amazon-firefox'],
+    ['Firefox', 'Tp6: YouTube', 'raptor-tp6-youtube-firefox'],
+    ['Firefox', 'Tp6: Google', 'raptor-tp6-google-firefox'],
+    ['Firefox', 'Tp6: Imdb', 'raptor-tp6-imdb-firefox'],
+    ['Firefox', 'Tp6: Imgur', 'raptor-tp6-imgur-firefox'],
+    ['Firefox', 'Tp6: Wikia', 'raptor-tp6-wikia-firefox'],
+    ['Firefox', 'Tp6: Bing', 'raptor-tp6-bing-firefox'],
+    ['Firefox', 'Tp6: Yandex', 'raptor-tp6-yandex-firefox'],
+    ['Firefox', 'Tp6: Apple', 'raptor-tp6-apple-firefox'],
+    ['Firefox', 'Tp6: Microsoft', 'raptor-tp6-microsoft-firefox'],
+    ['Firefox', 'Tp6: Reddit', 'raptor-tp6-reddit-firefox'],
+
+    ['Chrome', 'Tp6: Facebook', 'raptor-tp6-facebook-chrome'],
+    ['Chrome', 'Tp6: Amazon', 'raptor-tp6-amazon-chrome'],
+    ['Chrome', 'Tp6: Google', 'raptor-tp6-google-chrome'],
+    ['Chrome', 'Tp6: YouTube', 'raptor-tp6-youtube-chrome'],
+    ['Chrome', 'Tp6: Imdb', 'raptor-tp6-imdb-chrome'],
+    ['Chrome', 'Tp6: Imgur', 'raptor-tp6-imgur-chrome'],
+    ['Chrome', 'Tp6: Wikia', 'raptor-tp6-wikia-chrome'],
+    ['Chrome', 'Tp6: Bing', 'raptor-tp6-bing-chrome'],
+    ['Chrome', 'Tp6: Yandex', 'raptor-tp6-yandex-chrome'],
+    ['Chrome', 'Tp6: Apple', 'raptor-tp6-apple-chrome'],
+    ['Chrome', 'Tp6: Microsoft', 'raptor-tp6-microsoft-chrome'],
+    ['Chrome', 'Tp6: Reddit', 'raptor-tp6-reddit-chrome'],
+  ],
+};
+
+// ALL PAGE COMBINATIONS
+const TP6_PAGES = frum(SUITES.data)
+  .map(row => zipObject(SUITES.header, row))
+  .join('browser', PLATFORMS, 'browser')
+  .toArray();
+export { CONFIG, PLATFORMS, TP6_PAGES };

--- a/src/quantum/index-32bit.js
+++ b/src/quantum/index-32bit.js
@@ -9,7 +9,7 @@ import TelemetryContainer from '../telemetry/graph';
 import SETTINGS from '../settings';
 import { quantum32QueryParams, flowGraphProps, statusLabels } from './constants';
 import GraphContainer from '../components/graph-container';
-import CONFIG from './config';
+import { CONFIG } from './config';
 import wrapSectionComponentsWithErrorBoundaries from '../utils/componentEnhancers';
 import PerfherderGraphContainer from '../containers/PerfherderGraphContainer';
 
@@ -21,7 +21,6 @@ export default class QuantumIndex32 extends React.Component {
   }
 
   state = {
-    apzStatus: [],
     notes: {},
   };
 
@@ -105,111 +104,7 @@ export default class QuantumIndex32 extends React.Component {
         title: 'Performance Tests',
         rows: [
           [
-            <PerfherderGraphContainer
-              title='Tp6: Amazon'
-              series={[
-                {
-                  label: 'Firefox',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows7-32',
-                    option: 'pgo',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-amazon-firefox',
-                  },
-                },
-                {
-                  label: 'Chrome',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows7-32-nightly',
-                    option: 'opt',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-amazon-chrome',
-                  },
-                },
-              ]}
-            />,
-            <div style={{ width: '50%' }} />,
-          ],
-          [
-            <PerfherderGraphContainer
-              title='Tp6: Facebook'
-              series={[
-                {
-                  label: 'Firefox',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows7-32',
-                    option: 'pgo',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-facebook-firefox',
-                  },
-                },
-                {
-                  label: 'Chrome',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows7-32-nightly',
-                    option: 'opt',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-facebook-chrome',
-                  },
-                },
-              ]}
-            />,
-            <PerfherderGraphContainer
-              title='Tp6: Google'
-              series={[
-                {
-                  label: 'Firefox',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows7-32',
-                    option: 'pgo',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-google-firefox',
-                  },
-                },
-                {
-                  label: 'Chrome',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows7-32-nightly',
-                    option: 'opt',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-google-chrome',
-                  },
-                },
-              ]}
-            />,
-          ],
-          [
-            <PerfherderGraphContainer
-              title='Tp6: YouTube'
-              series={[
-                {
-                  label: 'Firefox',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows7-32',
-                    option: 'pgo',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-youtube-firefox',
-                  },
-                },
-                {
-                  label: 'Chrome',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows7-32-nightly',
-                    option: 'opt',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-youtube-chrome',
-                  },
-                },
-              ]}
-            />,
+            null,
             <PerfherderGraphContainer
               title='Page load (tp5)'
               series={[

--- a/src/quantum/index-64bit.js
+++ b/src/quantum/index-64bit.js
@@ -8,8 +8,8 @@ import Countdown from './countdown';
 import TelemetryContainer from '../telemetry/graph';
 import SETTINGS from '../settings';
 import { quantum64QueryParams, flowGraphProps, statusLabels } from './constants';
-import CONFIG from './config';
 import GraphContainer from '../components/graph-container';
+import { CONFIG } from './config';
 import wrapSectionComponentsWithErrorBoundaries from '../utils/componentEnhancers';
 import PerfherderGraphContainer from '../containers/PerfherderGraphContainer';
 
@@ -104,111 +104,7 @@ export default class QuantumIndex64 extends React.Component {
         title: 'Performance Tests',
         rows: [
           [
-            <PerfherderGraphContainer
-              title='Tp6: Amazon'
-              series={[
-                {
-                  label: 'Firefox',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows10-64',
-                    option: 'pgo',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-amazon-firefox',
-                  },
-                },
-                {
-                  label: 'Chrome',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows10-64-nightly',
-                    option: 'opt',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-amazon-chrome',
-                  },
-                },
-              ]}
-            />,
-            <div style={{ width: '50%' }} />,
-          ],
-          [
-            <PerfherderGraphContainer
-              title='Tp6: Facebook'
-              series={[
-                {
-                  label: 'Firefox',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows10-64',
-                    option: 'pgo',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-facebook-firefox',
-                  },
-                },
-                {
-                  label: 'Chrome',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows10-64-nightly',
-                    option: 'opt',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-facebook-chrome',
-                  },
-                },
-              ]}
-            />,
-            <PerfherderGraphContainer
-              title='Tp6: Google'
-              series={[
-                {
-                  label: 'Firefox',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows10-64',
-                    option: 'pgo',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-google-firefox',
-                  },
-                },
-                {
-                  label: 'Chrome',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows10-64-nightly',
-                    option: 'opt',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-google-chrome',
-                  },
-                },
-              ]}
-            />,
-          ],
-          [
-            <PerfherderGraphContainer
-              title='Tp6: YouTube'
-              series={[
-                {
-                  label: 'Firefox',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows10-64',
-                    option: 'pgo',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-youtube-firefox',
-                  },
-                },
-                {
-                  label: 'Chrome',
-                  seriesConfig: {
-                    frameworkId: 10,
-                    platform: 'windows10-64-nightly',
-                    option: 'opt',
-                    project: 'mozilla-central',
-                    suite: 'raptor-tp6-youtube-chrome',
-                  },
-                },
-              ]}
-            />,
+            null,
             <PerfherderGraphContainer
               title='Page load (tp5)'
               series={[
@@ -625,15 +521,6 @@ export default class QuantumIndex64 extends React.Component {
               title='Time to First Scroll ms'
               queryParams={quantum64QueryParams}
             />,
-          ],
-          [
-            <TelemetryContainer
-              key='blankWindowShown'
-              id='blankWindowShown'
-              title='Blank window shown'
-              queryParams={quantum64QueryParams}
-            />,
-            <div style={{ width: '50%' }} />,
           ],
         ],
       },

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,6 +8,7 @@ import JsTeam from './views/JsTeam';
 import NimbledroidGraphPage from './views/NimbledroidGraph';
 import Quantum64 from './quantum/index-64bit';
 import Quantum32 from './quantum/index-32bit';
+import TP6 from './views/QuantumTP6/index';
 import Subbenchmark from './quantum/subbenchmarks';
 import FlowTable from './quantum/flow-table';
 
@@ -16,6 +17,7 @@ const NoMatch = () => <div>404</div>;
 const Routes = () => (
   <BrowserRouter>
     <Switch>
+      <Route path='/quantum/tp6' component={TP6} />
       <Route path='/android/graph' component={NimbledroidGraphPage} />
       <Route path='/android' component={AndroidPage} />
       <Route path='/quantum/:architecture/bugs' component={FlowTable} />

--- a/src/utils/queryOps.js
+++ b/src/utils/queryOps.js
@@ -1,0 +1,129 @@
+import lodashGroupBy from 'lodash/groupBy';
+import map from 'lodash/map';
+import flatten from 'lodash/flatten';
+import lodashFilter from 'lodash/filter';
+import toPairs from 'lodash/toPairs';
+import chunk from 'lodash/chunk';
+import unzip from 'lodash/unzip';
+import sortBy from 'lodash/sortBy';
+import fromPairs from 'lodash/fromPairs';
+
+class Wrapper {
+  constructor(list) {
+    this.list = list;
+  }
+
+  toArray() {
+    return this.list;
+  }
+}
+
+
+// Add a chainable method to Wrapper
+const extend_wrapper = (methods) => {
+  toPairs(methods).forEach(([name, method]) => {
+    // USE function(){} DECLARATION TO BIND this AT CALL TIME
+    Wrapper.prototype[name] = function anonymous(...args) {
+      this.list = method(this.list, ...args);
+      return this;
+    };
+  });
+};
+
+
+const frum = (list) => {
+  return new Wrapper(list);
+};
+
+
+extend_wrapper({
+  map: map,
+  lodashFilter: lodashFilter,
+  flatten: flatten,
+  toPairs: toPairs,
+  chunk: chunk,
+  unzip: unzip,
+  sortBy: sortBy,
+  fromPairs: fromPairs,
+  lodashGroupBy: lodashGroupBy,
+});
+
+
+const toArray = (value) => {
+  if (Array.isArray(value)) {
+    return value;
+  } if (value == null) {
+    return [];
+  }
+    return [value];
+};
+
+// convert string into function that selects column from row
+const selector = (column_name) => {
+  if (typeof column_name === 'string') {
+    return row => row[column_name];
+  }
+    return column_name;
+
+};
+
+
+extend_wrapper({
+  // Groupby one, or many, columns by name or by {name: selector} pairs
+  // return array of [rows, key, index] tuples
+  groupBy: function groupBy(list, columns) {
+    const cs = frum(toArray(columns))
+      .map((col_name) => {
+        if (typeof col_name === 'string') {
+          return [[col_name, selector(col_name)]];
+        }
+        return toPairs(col_name).map(([name, value]) => [name, selector(value)]);
+      })
+      .flatten()
+      .sortBy(([col_name]) => col_name)
+      .toArray();
+
+    const output = {};
+    let i = 0;
+    list.forEach((row) => {
+      const key = fromPairs(cs.map(([name, func]) => [name, func(row)]));
+      const skey = JSON.stringify(key);
+
+      let triple = output[skey];
+      if (!triple) {
+        triple = [[], key, i];
+        i += 1;
+        output[skey] = triple;
+      }
+      triple[0].push(row);
+    });
+    return Object.values(output);
+  },
+
+  // SELECT a.*, b.* FROM listA a LEFT JOIN listB b on b[propB]=a[propA]
+  join: function join(listA, propA, listB, propB) {
+    const lookup = frum(listB)
+      .lodashGroupBy(rowB => rowB[propB])
+      .toArray();
+
+    return frum(listA)
+      .map(rowA => lookup[rowA[propA]].map((rowB) => { return { ...rowB, ...rowA }; }))
+      .flatten()
+      .toArray();
+  },
+
+  // Expecting a object of {column_name: value} form to use as a filter
+  // return only matching rows
+  filter: function filter(list, expression) {
+    const func = (row) => {
+      for (const [name, value] of toPairs(expression)) {
+        if (row[name] !== value) return false;
+      }
+      return true;
+    };
+
+    return lodashFilter(list, func);
+  },
+});
+
+export default frum;

--- a/src/views/QuantumTP6/index.js
+++ b/src/views/QuantumTP6/index.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core';
+import PropTypes from 'prop-types';
+import Grid from '@material-ui/core/Grid';
+import frum from '../../utils/queryOps';
+import { TP6_PAGES } from '../../quantum/config';
+import DashboardPage from '../../components/DashboardPage';
+import PerfherderGraphContainer from '../../containers/PerfherderGraphContainer';
+
+const styles = {
+  body: {
+    backgroundColor: 'white',
+  },
+  chart: {
+    justifyContent: 'center',
+    padding: '1rem',
+  },
+};
+
+class TP6 extends React.Component {
+  constructor(props) {
+    super(props);
+    const { location } = this.props;
+    const params = new URLSearchParams(location.search);
+    this.state = { bits: params.get('bits') };
+  }
+
+  render() {
+    const { classes } = this.props;
+    const state = this.state;
+
+    return (
+      <div className={classes.body}>
+        <DashboardPage
+          key={state.bits}
+          title={'TP6'}
+          subtitle={`Page load on ${state.bits} bits`}
+        >
+          <Grid container spacing={24}>
+            {
+              frum(TP6_PAGES)
+                .filter(state)
+                .groupBy('title')
+                .map(([series, { title }]) => (
+                  <Grid item xs={6} key={`page_${title}_${state.bits}`} className={classes.chart}>
+                    <PerfherderGraphContainer
+                      title={title}
+                      series={series.map((s) => { return { label: s.label, seriesConfig: s }; })}
+                    />
+                  </Grid>
+                ))
+                .toArray()
+            }
+          </Grid>
+        </DashboardPage>
+      </div>
+    );
+  }
+}
+
+
+TP6.propTypes = {
+  classes: PropTypes.shape({}).isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+
+export default withStyles(styles)(TP6);

--- a/src/views/QuantumTP6/index.js
+++ b/src/views/QuantumTP6/index.js
@@ -27,22 +27,22 @@ class TP6 extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const state = this.state;
+    const { bits } = this.state;
 
     return (
       <div className={classes.body}>
         <DashboardPage
-          key={state.bits}
+          key={bits}
           title={'TP6'}
-          subtitle={`Page load on ${state.bits} bits`}
+          subtitle={`Page load on ${bits} bits`}
         >
           <Grid container spacing={24}>
             {
               frum(TP6_PAGES)
-                .filter(state)
+                .filter({ bits: bits })
                 .groupBy('title')
                 .map(([series, { title }]) => (
-                  <Grid item xs={6} key={`page_${title}_${state.bits}`} className={classes.chart}>
+                  <Grid item xs={6} key={`page_${title}_${bits}`} className={classes.chart}>
                     <PerfherderGraphContainer
                       title={title}
                       series={series.map((s) => { return { label: s.label, seriesConfig: s }; })}


### PR DESCRIPTION
#204 - Update dashboard for new tp6 suites (part 1)

Add QuantumTP6 view to show known tp6 metrics

* attempt to use ChartJS

* remove tp6, for moving to other page

* revert

* first version attempt

* first working version

* try this

* slightly better, prepare for url parameters

* do not need 64 bit, adding it as url parameter later

* move back to original position

* combine 32 and 64

* lint fix

* remove warning

* whitespace

* comments

* some changes from feedback

* simplify tp6, replace lodash with query_ops

* use Grid

* remove line

* move constructor logic back to render()

* whitespace

* use toArray instead of value

* use url search parameters

* remove comments

* fix ugly styles from the merge

* remove not needed styles

* docs?

* docs

* remove docs

* PR feedback

* Update src/views/QuantumTP6/index.js

Co-Authored-By: klahnakoski <klahnakoski@mozilla.com>

* Update src/views/QuantumTP6/index.js

Co-Authored-By: klahnakoski <klahnakoski@mozilla.com>