### PR TITLE
 Issue #211 - Add persistent tooltip

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,15 @@ import { AppContainer } from 'react-hot-loader';
 import './index.css';
 import GenericErrorBoundary from './components/genericErrorBoundary';
 import Routes from './routes';
+import registerTooltip from './utils/registerTooltip';
 
 require('typeface-roboto');
 
 if (process.env.NODE_ENV === 'production') {
   Raven.config('https://77916a47017347528d25824beb0a077e@sentry.io/1225660').install();
 }
+// handle sticky tooltip for all charts
+registerTooltip();
 
 const root = document.getElementById('root');
 const load = () => render(

--- a/src/utils/registerTooltip.jsx
+++ b/src/utils/registerTooltip.jsx
@@ -8,10 +8,10 @@ const handleOnClick = (_, items) => {
         // the current tooltip in view has a reference to the last active tooltip
         // eslint-disable-next-line no-underscore-dangle
         Chart.lastClickedDataPoint = items[0]._chart.tooltip._lastActive[0];
-        Chart.helpers.each(Chart.instances, (chartItem) => {
-            chartItem.update();
-        });
     }
+    Chart.helpers.each(Chart.instances, (chartItem) => {
+      chartItem.update();
+  });
 };
 
 const registerPlugin = () => {

--- a/src/utils/registerTooltip.jsx
+++ b/src/utils/registerTooltip.jsx
@@ -1,0 +1,56 @@
+import Chart from 'chart.js';
+
+const handleOnClick = (_, items) => {
+    Chart.lastClickedDataPoint = null;
+    // Check if the click happened on empty chart space or data point
+    if (items.length > 0) {
+        // A Chart element has a reference to which chart it belongs to and what
+        // the current tooltip in view has a reference to the last active tooltip
+        // eslint-disable-next-line no-underscore-dangle
+        Chart.lastClickedDataPoint = items[0]._chart.tooltip._lastActive[0];
+        Chart.helpers.each(Chart.instances, (chartItem) => {
+            chartItem.update();
+        });
+    }
+};
+
+const registerPlugin = () => {
+    Chart.plugins.register({
+        id: 'tooltip-plugin',
+        beforeRender(chart) {
+          this.pluginTooltips = [];
+          // Process only if a data point was clicked
+          if (Chart.lastClickedDataPoint) {
+            // eslint-disable-next-line no-underscore-dangle
+            if (Chart.lastClickedDataPoint._chart.chart.id !== chart.id) {
+              return;
+            }
+            const { _datasetIndex, _index } = Chart.lastClickedDataPoint;
+
+            this.pluginTooltips.push(new Chart.Tooltip({
+              _chart: chart.chart,
+              _chartInstance: chart,
+              _data: chart.data,
+              _options: chart.options.tooltips,
+              // eslint-disable-next-line no-underscore-dangle
+              _active: [chart.getDatasetMeta(_datasetIndex).data[_index]],
+            }, chart));
+          }
+        },
+        afterDatasetsDraw(easing) {
+          Chart.helpers.each(this.pluginTooltips, (tooltip) => {
+            tooltip.initialize();
+            tooltip.update();
+            tooltip.pivot();
+            tooltip.transition(easing).draw();
+          });
+        },
+      });
+};
+
+const registerTooltipPlugin = () => {
+  registerPlugin();
+  Chart.defaults.global.onClick = handleOnClick;
+};
+
+export default registerTooltipPlugin;


### PR DESCRIPTION
I need some thoughts here. 

As we are continuing [Akansha's work](https://github.com/asingh217/firefox-performance-dashboard/commit/1274e01f5393b8d5c7c84778eb8b0218f151fbfd), I checked and it is working fine. 

[This piece of code looks good](https://github.com/asingh217/firefox-performance-dashboard/commit/1274e01f5393b8d5c7c84778eb8b0218f151fbfd#diff-c0ed5edad59ea667c2a52980e70e7557) and i found something very similar while searching. So i decided to go with this code and not wasting time on redoing it. 

[In a comment](https://github.com/mozilla-frontend-infra/firefox-performance-dashboard/pull/104#discussion_r231936040) @armenzg  said that we want a HOC based solution. 

So, i read about HOC and tried to implement this in this project. 

I am a little confused from now onwards, In my understanding we want 

- a function under utility to deal with persistent tooltip logic
- a hoc component under /hoc/ which will accept a wrappedComponent, that wrapped component would be a ChartJSWrapper 
- we will then pass our chartJSWrapper in our HOC to implement this logic in graph 

for example if we want perfherdergraphcontainer to be stick we will have to do something [here](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/containers/PerfherderGraphContainer/index.jsx#L46) 
somehow pass the graphwrapper in hoc, and get that logic implement on it... may be.

Please check updated files, i am a little stuck at this point.

Any thought @sarah-clements or @armenzg 