### PR TITLE
Show bug burndown for GeckoView Fenix bugs

### DIFF
--- a/src/views/Android/index.jsx
+++ b/src/views/Android/index.jsx
@@ -18,19 +18,19 @@ class Android extends Component {
             includeBugCount
             queries={[
               {
-                text: 'Open P1 bugs',
+                text: 'Open fenix:p1 bugs',
                 parameters: {
                   product: 'GeckoView',
                   resolution: '---',
-                  priority: ['P1'],
+                  whiteboard: '[geckoview:fenix:p1]',
                 },
               },
               {
-                text: 'Open P2/P3 bugs',
+                text: 'Open fenix:p2 bugs',
                 parameters: {
                   product: 'GeckoView',
                   resolution: '---',
-                  priority: ['P2', 'P3'],
+                  whiteboard: '[geckoview:fenix:p2]',
                 },
               },
             ]}
@@ -38,24 +38,24 @@ class Android extends Component {
           <BugzillaGraph
             queries={[
               {
-                label: 'P1 bugs',
+                label: 'fenix:p1 bugs',
                 parameters: {
                   product: 'GeckoView',
                   resolution: ['---', 'FIXED'],
-                  priority: ['P1'],
+                  whiteboard: '[geckoview:fenix:p1]',
                 },
               },
               {
-                label: 'P2/P3 bugs',
+                label: 'fenix:p2 bugs',
                 parameters: {
                   product: 'GeckoView',
                   resolution: ['---', 'FIXED'],
-                  priority: ['P2', 'P3'],
+                  whiteboard: '[geckoview:fenix:p2]',
                 },
               },
             ]}
             startDate='2018-03-01'
-            title='GeckoView bugs'
+            title='GeckoView Fenix bugs'
           />
         </Section>
         <Section title='Nimbledroid' subtitle='GeckoView vs Chrome Beta'>


### PR DESCRIPTION
The Android dashboard's bug burndown currently shows GeckoView P1 and P2/P3 bugs. We'll never actually burn down to zero P1 bugs because we'll continue to promote P2 bugs to P1. 😄 A more useful bug query to track is the number the GeckoView bugs that block the [Fenix 1.0 release](https://github.com/mozilla-mobile/fenix/).