### PR TITLE
enable linting rules

### DIFF
--- a/test/components/graph-container.test.js
+++ b/test/components/graph-container.test.js
@@ -1,33 +1,36 @@
+/* eslint-disable jest/valid-expect */
 /* global describe, it */
-/* eslint-disable */
 import assert from 'assert';
 import { expect } from 'chai';
-import { transformGraphData, determineStatusColor } from '../../src/utils/helpers';
+import {
+  transformGraphData,
+  determineStatusColor,
+} from '../../src/utils/helpers';
 
 describe('transformGraphData', () => {
   it('should take an array of objects and transform it into many arrays of objects', () => {
-
     const keys = ['value1', 'value2'];
     const dataInput = [
       { value1: 3, value2: 8, date: '2018-05-03' },
       { value1: 7, value2: 13, date: '2018-05-02' },
       { value1: 9, value2: 5, date: '2018-05-01' },
     ];
-
     const expectedData = [
       [
         { value: 3, date: new Date('2018-05-03') },
         { value: 7, date: new Date('2018-05-02') },
         { value: 9, date: new Date('2018-05-01') },
-      ], [
+      ],
+      [
         { value: 8, date: new Date('2018-05-03') },
         { value: 13, date: new Date('2018-05-02') },
         { value: 5, date: new Date('2018-05-01') },
       ],
     ];
-
     const actual = transformGraphData(keys, dataInput);
-    assert(keys.length === Object.keys(dataInput[0]).length - 1); // date should be omitted from keys list
+
+    assert(keys.length === Object.keys(dataInput[0]).length - 1);
+    // date should be omitted from keys list
     expect(actual).to.eql(expectedData);
   });
 });
@@ -43,7 +46,6 @@ describe('determineStatusColor', () => {
       { value1: 7, value2: 13, date: '2018-05-03' },
       { value1: 9, value2: 5, date: '2018-05-02' },
     ];
-
     const actual = determineStatusColor(dataInput, targetLine, targetValue);
     const actual2 = determineStatusColor(dataInput, targetLine2, targetValue2);
 

--- a/test/utils/subbenchmarks.test.js
+++ b/test/utils/subbenchmarks.test.js
@@ -1,5 +1,5 @@
+/* eslint-disable jest/valid-expect */
 /* global describe, it */
-/* eslint-disable */
 import assert from 'assert';
 import { expect } from 'chai';
 import { adjustedData } from '../../src/utils/perfherder/subbenchmarks';
@@ -14,6 +14,7 @@ const stubData = [
 describe('subbenchmarks', () => {
   it('adjustData() - only keep 50th percentile of data', () => {
     const data = adjustedData(stubData, 50);
+
     assert(data.length === 2);
     expect(data.map(d => d.value)).to.have.same.members([1, 2]);
   });


### PR DESCRIPTION
Issue https://github.com/mozilla-frontend-infra/firefox-health-dashboard/issues/293 : Some linting rules are disabled as those were giving errors. I have fixed a few in this PR and remaining need to be fixed. 

Please read the comments on the issue https://github.com/mozilla-frontend-infra/firefox-health-dashboard/issues/293. 