### PR TITLE
Issue #83 - Add error handling

### DIFF
--- a/src/components/ChartJsWrapper/index.jsx
+++ b/src/components/ChartJsWrapper/index.jsx
@@ -21,8 +21,8 @@ const styles = {
     padding: '.3rem .3rem .3rem .3rem',
   },
   errorPanel: {
-    marginTop: '10px',
-    width: '97%',
+    margin: '26px auto 40px',
+    width: '70%',
   },
 };
 const ChartJsWrapper = ({
@@ -73,6 +73,10 @@ const ChartJsWrapper = ({
         textAlign: 'center',
         width: spinnerSize,
       }}>
+      <ErrorPanel
+        className={classes.errorPanel}
+        error="Something went wrong, please try again later."
+      />
       <CircularProgress />
     </div>
   );
@@ -123,7 +127,7 @@ ChartJsWrapper.defaultProps = {
   title: '',
   type: 'line',
   chartHeight: 80,
-  spinnerSize: '8rem',
+  spinnerSize: '100%',
 };
 
 export default withStyles(styles)(ChartJsWrapper);

--- a/src/components/ChartJsWrapper/index.jsx
+++ b/src/components/ChartJsWrapper/index.jsx
@@ -111,6 +111,7 @@ ChartJsWrapper.propTypes = {
   }),
   title: PropTypes.string,
   type: PropTypes.string,
+  isLoading: PropTypes.bool,
   chartHeight: PropTypes.number,
   spinnerSize: PropTypes.string,
   missingDataError: PropTypes.bool,
@@ -124,6 +125,7 @@ ChartJsWrapper.defaultProps = {
   type: 'line',
   chartHeight: 80,
   spinnerSize: '100%',
+  isLoading: false,
 };
 
 export default withStyles(styles)(ChartJsWrapper);

--- a/src/components/ChartJsWrapper/index.jsx
+++ b/src/components/ChartJsWrapper/index.jsx
@@ -73,10 +73,6 @@ const ChartJsWrapper = ({
         textAlign: 'center',
         width: spinnerSize,
       }}>
-      <ErrorPanel
-        className={classes.errorPanel}
-        error="Something went wrong, please try again later."
-      />
       <CircularProgress />
     </div>
   );

--- a/src/components/criticalErrorMessage.jsx
+++ b/src/components/criticalErrorMessage.jsx
@@ -16,6 +16,7 @@ export const CriticalErrorMessage = () => (
     </a>
   </p>
 );
+
 export const DefaultErrorMessage = props => (
   <ErrorPanel
     className={props.style}
@@ -28,4 +29,10 @@ export const MissingDataErrorMessage = props => (
     className={props.style}
     error="This item has been missing data for at least 3 days."
   />
+);
+
+export const IvalidUrlMessage = () => (
+  <p style={{ textAlign: 'center', fontSize: '1.5em' }}>
+    <span>You have entered an invalid URL.</span>
+  </p>
 );

--- a/src/components/criticalErrorMessage.jsx
+++ b/src/components/criticalErrorMessage.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import ErrorPanel from '@mozilla-frontend-infra/components/ErrorPanel';
 
 const newIssue =
   'https://github.com/mozilla/firefox-health-dashboard/issues/new';
-const CriticalErrorMessage = () => (
+
+export const CriticalErrorMessage = () => (
   <p style={{ textAlign: 'center', fontSize: '1.5em' }}>
     <span>
       There has been a critical error. We have reported it. If the issue is not
@@ -14,5 +16,16 @@ const CriticalErrorMessage = () => (
     </a>
   </p>
 );
+export const DefaultErrorMessage = props => (
+  <ErrorPanel
+    className={props.style}
+    error="Something went wrong, please try again later."
+  />
+);
 
-export default CriticalErrorMessage;
+export const MissingDataErrorMessage = props => (
+  <ErrorPanel
+    className={props.style}
+    error="This item has been missing data for at least 3 days."
+  />
+);

--- a/src/components/criticalErrorMessage.jsx
+++ b/src/components/criticalErrorMessage.jsx
@@ -31,7 +31,7 @@ export const MissingDataErrorMessage = props => (
   />
 );
 
-export const IvalidUrlMessage = () => (
+export const InvalidUrlMessage = () => (
   <p style={{ textAlign: 'center', fontSize: '1.5em' }}>
     <span>You have entered an invalid URL.</span>
   </p>

--- a/src/components/genericErrorBoundary.jsx
+++ b/src/components/genericErrorBoundary.jsx
@@ -1,7 +1,7 @@
 import Raven from 'raven-js';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import CriticalErrorMessage from './criticalErrorMessage';
+import { CriticalErrorMessage } from './criticalErrorMessage';
 
 export default class ErrorBoundary extends Component {
   state = {

--- a/src/containers/BugzillaGraph/index.jsx
+++ b/src/containers/BugzillaGraph/index.jsx
@@ -18,9 +18,10 @@ class BugzillaGraph extends Component {
     try {
       this.setState({ isLoading: true });
       this.setState(await getBugsData(queries, startDate));
-      this.setState({ isLoading: false });
     } catch (error) {
       handleError(error);
+    } finally {
+      this.setState({ isLoading: false });
     }
   }
 

--- a/src/containers/BugzillaGraph/index.jsx
+++ b/src/containers/BugzillaGraph/index.jsx
@@ -7,6 +7,7 @@ import getBugsData from '../../utils/bugzilla/getBugsData';
 class BugzillaGraph extends Component {
   state = {
     data: null,
+    isLoading: false,
   };
 
   async componentDidMount() {
@@ -15,19 +16,22 @@ class BugzillaGraph extends Component {
 
   async fetchData({ handleError, queries, startDate }) {
     try {
+      this.setState({ isLoading: true });
       this.setState(await getBugsData(queries, startDate));
+      this.setState({ isLoading: false });
     } catch (error) {
       handleError(error);
     }
   }
 
   render() {
-    const { data } = this.state;
+    const { data, isLoading } = this.state;
     const { title } = this.props;
 
     return (
       <ChartJsWrapper
         data={data}
+        isLoading={isLoading}
         options={{ scaleLabel: 'Number of bugs' }}
         title={title}
       />

--- a/src/containers/PerfherderGraphContainer/index.jsx
+++ b/src/containers/PerfherderGraphContainer/index.jsx
@@ -33,8 +33,7 @@ class PerfherderGraphContainer extends Component {
     try {
       this.setState({ isLoading: true });
       this.setState(await getPerferherderData(series));
-      this.setState({ isLoading: false });
-    } catch (error) {
+    } finally {
       this.setState({ isLoading: false });
     }
   }

--- a/src/containers/PerfherderGraphContainer/index.jsx
+++ b/src/containers/PerfherderGraphContainer/index.jsx
@@ -22,6 +22,7 @@ const styles = () => ({
 class PerfherderGraphContainer extends Component {
   state = {
     data: null,
+    isLoading: false,
   };
 
   async componentDidMount() {
@@ -29,12 +30,18 @@ class PerfherderGraphContainer extends Component {
   }
 
   async fetchSetData({ series }) {
-    this.setState(await getPerferherderData(series));
+    try {
+      this.setState({ isLoading: true });
+      this.setState(await getPerferherderData(series));
+      this.setState({ isLoading: false });
+    } catch (error) {
+      this.setState({ isLoading: false });
+    }
   }
 
   render() {
     const { classes, title } = this.props;
-    const { data, jointUrl, options } = this.state;
+    const { data, jointUrl, options, isLoading } = this.state;
 
     return (
       <div key={title}>
@@ -49,6 +56,7 @@ class PerfherderGraphContainer extends Component {
         <ChartJsWrapper
           type="line"
           data={data}
+          isLoading={isLoading}
           options={options}
           missingDataError
         />

--- a/src/containers/RedashContainer/index.jsx
+++ b/src/containers/RedashContainer/index.jsx
@@ -18,6 +18,7 @@ const styles = {
 class RedashContainer extends Component {
   state = {
     datasets: null,
+    isLoading: false,
   };
 
   static propTypes = {
@@ -59,16 +60,22 @@ class RedashContainer extends Component {
   }
 
   async fetchSetState({ dataKeyIdentifier, redashDataUrl }) {
-    const redashData = await fetchJson(redashDataUrl);
+    try {
+      this.setState({ isLoading: true });
+      const redashData = await fetchJson(redashDataUrl);
 
-    this.setState({
-      datasets: telemetryDataToDatasets(redashData, dataKeyIdentifier),
-    });
+      this.setState({
+        datasets: telemetryDataToDatasets(redashData, dataKeyIdentifier),
+      });
+      this.setState({ isLoading: false });
+    } catch (error) {
+      this.setState({ isLoading: false });
+    }
   }
 
   render() {
     const { classes, options, redashQueryUrl, title } = this.props;
-    const { datasets } = this.state;
+    const { datasets, isLoading } = this.state;
 
     return (
       <div>
@@ -76,6 +83,7 @@ class RedashContainer extends Component {
           title={title}
           type="line"
           data={datasets}
+          isLoading={isLoading}
           options={options}
         />
         <div className={classes.linkContainer}>

--- a/src/containers/RedashContainer/index.jsx
+++ b/src/containers/RedashContainer/index.jsx
@@ -67,8 +67,7 @@ class RedashContainer extends Component {
       this.setState({
         datasets: telemetryDataToDatasets(redashData, dataKeyIdentifier),
       });
-      this.setState({ isLoading: false });
-    } catch (error) {
+    } finally {
       this.setState({ isLoading: false });
     }
   }

--- a/src/hocs/withErrorBoundary.jsx
+++ b/src/hocs/withErrorBoundary.jsx
@@ -1,7 +1,7 @@
 import Raven from 'raven-js';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import CriticalErrorMessage from '../components/criticalErrorMessage';
+import { CriticalErrorMessage } from '../components/criticalErrorMessage';
 
 const reportOrLog = (error, info) => {
   if (process.env.NODE_ENV === 'production') {

--- a/src/quantum/perfherder.jsx
+++ b/src/quantum/perfherder.jsx
@@ -15,7 +15,7 @@ import {
   timeMonth,
 } from 'd3';
 import { stringify } from 'query-string';
-import CriticalErrorMessage from '../components/criticalErrorMessage';
+import { CriticalErrorMessage } from '../components/criticalErrorMessage';
 import Widget from './widget';
 import SETTINGS from '../settings';
 

--- a/src/telemetry/graph.jsx
+++ b/src/telemetry/graph.jsx
@@ -17,7 +17,7 @@ const styles = {
 
 class TelemetryContainer extends React.Component {
   state = {
-    showErrorMsg: false,
+    error: false,
   };
 
   async componentDidMount() {
@@ -45,7 +45,7 @@ class TelemetryContainer extends React.Component {
       this.graphSubtitleEl.textContent = graphData.description;
       this.graphEvolutionsTimeline(graphData, this.graphEl);
     } catch (error) {
-      this.setState({ showErrorMsg: true });
+      this.setState({ error: true });
       // eslint-disable-next-line no-console
       console.error(error.message);
     }
@@ -80,7 +80,7 @@ class TelemetryContainer extends React.Component {
 
   render() {
     const { id, title, classes } = this.props;
-    const { showErrorMsg } = this.state;
+    const { error } = this.state;
 
     if (title) {
       return (
@@ -94,7 +94,7 @@ class TelemetryContainer extends React.Component {
               </a>
             </h3>
           </header>
-          {showErrorMsg ? (
+          {error ? (
             <DefaultErrorMessage style={classes.errorPanel} />
           ) : (
             <div>

--- a/src/telemetry/graph.jsx
+++ b/src/telemetry/graph.jsx
@@ -4,12 +4,12 @@ import MG from 'metrics-graphics';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { stringify } from 'query-string';
-import ErrorPanel from '@mozilla-frontend-infra/components/ErrorPanel';
 import { withStyles } from '@material-ui/core/styles';
 import SETTINGS from '../settings';
+import { DefaultErrorMessage } from '../components/criticalErrorMessage';
 
 const styles = {
-  errorPanelClass: {
+  errorPanel: {
     margin: '40px auto',
     width: '50%',
   },
@@ -17,7 +17,7 @@ const styles = {
 
 class TelemetryContainer extends React.Component {
   state = {
-    errorFlag: false,
+    showErrorMsg: false,
   };
 
   async componentDidMount() {
@@ -45,7 +45,7 @@ class TelemetryContainer extends React.Component {
       this.graphSubtitleEl.textContent = graphData.description;
       this.graphEvolutionsTimeline(graphData, this.graphEl);
     } catch (error) {
-      this.setState({ errorFlag: true });
+      this.setState({ showErrorMsg: true });
       // eslint-disable-next-line no-console
       console.error(error.message);
     }
@@ -80,7 +80,7 @@ class TelemetryContainer extends React.Component {
 
   render() {
     const { id, title, classes } = this.props;
-    const { errorFlag } = this.state;
+    const { showErrorMsg } = this.state;
 
     if (title) {
       return (
@@ -94,11 +94,8 @@ class TelemetryContainer extends React.Component {
               </a>
             </h3>
           </header>
-          {errorFlag ? (
-            <ErrorPanel
-              className={classes.errorPanelClass}
-              error="Something went wrong, please try again later."
-            />
+          {showErrorMsg ? (
+            <DefaultErrorMessage style={classes.errorPanel} />
           ) : (
             <div>
               <div

--- a/src/telemetry/graph.jsx
+++ b/src/telemetry/graph.jsx
@@ -4,9 +4,22 @@ import MG from 'metrics-graphics';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { stringify } from 'query-string';
+import ErrorPanel from '@mozilla-frontend-infra/components/ErrorPanel';
+import { withStyles } from '@material-ui/core/styles';
 import SETTINGS from '../settings';
 
-export default class TelemetryContainer extends React.Component {
+const styles = {
+  errorPanelClass: {
+    margin: '40px auto',
+    width: '50%',
+  },
+};
+
+class TelemetryContainer extends React.Component {
+  state = {
+    errorFlag: false,
+  };
+
   async componentDidMount() {
     this.fetchPlotGraph(this.props.id, this.props.queryParams);
   }
@@ -32,6 +45,7 @@ export default class TelemetryContainer extends React.Component {
       this.graphSubtitleEl.textContent = graphData.description;
       this.graphEvolutionsTimeline(graphData, this.graphEl);
     } catch (error) {
+      this.setState({ errorFlag: true });
       // eslint-disable-next-line no-console
       console.error(error.message);
     }
@@ -65,29 +79,41 @@ export default class TelemetryContainer extends React.Component {
   }
 
   render() {
-    const { id, title } = this.props;
+    const { id, title, classes } = this.props;
+    const { errorFlag } = this.state;
 
-    return (
-      <div id={id} key={id} className="criteria-widget">
-        <header>
-          <h3 className="graph-title">
-            <a
-              className="graph-title-link"
-              ref={a => (this.graphTitleLink = a)}>
-              {title}
-            </a>
-          </h3>
-        </header>
-        <div
-          className="graph-subtitle"
-          ref={div => (this.graphSubtitleEl = div)}>
-          {}
+    if (title) {
+      return (
+        <div id={id} key={id} className="criteria-widget">
+          <header>
+            <h3 className="graph-title">
+              <a
+                className="graph-title-link"
+                ref={a => (this.graphTitleLink = a)}>
+                {title}
+              </a>
+            </h3>
+          </header>
+          {errorFlag ? (
+            <ErrorPanel
+              className={classes.errorPanelClass}
+              error="Something went wrong, please try again later."
+            />
+          ) : (
+            <div>
+              <div
+                className="graph-subtitle"
+                ref={div => (this.graphSubtitleEl = div)}>
+                {}
+              </div>
+              <div className="graph" ref={div => (this.graphEl = div)}>
+                <div className="graph-legend">{}</div>
+              </div>
+            </div>
+          )}
         </div>
-        <div className="graph" ref={div => (this.graphEl = div)}>
-          <div className="graph-legend">{}</div>
-        </div>
-      </div>
-    );
+      );
+    }
   }
 }
 
@@ -96,3 +122,5 @@ TelemetryContainer.propTypes = {
   title: PropTypes.string.isRequired,
   queryParams: PropTypes.shape({}),
 };
+
+export default withStyles(styles)(TelemetryContainer);

--- a/src/views/QuantumTP6/index.jsx
+++ b/src/views/QuantumTP6/index.jsx
@@ -9,6 +9,7 @@ import { withNavigation } from '../../vendor/utils/navigation';
 import Picker from '../../vendor/utils/navigation/Picker';
 import DashboardPage from '../../components/DashboardPage';
 import PerfherderGraphContainer from '../../containers/PerfherderGraphContainer';
+import { IvalidUrlMessage } from '../../components/criticalErrorMessage';
 
 const styles = {
   body: {
@@ -29,38 +30,41 @@ class TP6 extends React.Component {
         .first().label
     } on ${bits} bits`;
 
-    return (
-      <div className={classes.body}>
-        <DashboardPage key={subtitle} title="TP6 Desktop" subtitle={subtitle}>
-          {navigation}
-          <Grid container spacing={24}>
-            {frum(TP6_PAGES)
-              .where({ bits })
-              .groupBy('title')
-              .map((series, title) => (
-                <Grid
-                  item
-                  xs={6}
-                  key={`page_${title}_${test}_${bits}`}
-                  className={classes.chart}>
-                  <PerfherderGraphContainer
-                    title={title}
-                    series={frum(series)
-                      .sortBy(['browser'])
-                      .reverse()
-                      .map(s => ({
-                        label: s.label,
-                        seriesConfig: { ...s, test },
-                        options: { includeSubtests: true },
-                      }))
-                      .toArray()}
-                  />
-                </Grid>
-              ))}
-          </Grid>
-        </DashboardPage>
-      </div>
-    );
+    if (bits === '32' || bits === '64')
+      return (
+        <div className={classes.body}>
+          <DashboardPage key={subtitle} title="TP6 Desktop" subtitle={subtitle}>
+            {navigation}
+            <Grid container spacing={24}>
+              {frum(TP6_PAGES)
+                .where({ bits })
+                .groupBy('title')
+                .map((series, title) => (
+                  <Grid
+                    item
+                    xs={6}
+                    key={`page_${title}_${test}_${bits}`}
+                    className={classes.chart}>
+                    <PerfherderGraphContainer
+                      title={title}
+                      series={frum(series)
+                        .sortBy(['browser'])
+                        .reverse()
+                        .map(s => ({
+                          label: s.label,
+                          seriesConfig: { ...s, test },
+                          options: { includeSubtests: true },
+                        }))
+                        .toArray()}
+                    />
+                  </Grid>
+                ))}
+            </Grid>
+          </DashboardPage>
+        </div>
+      );
+
+    return <IvalidUrlMessage />;
   }
 }
 

--- a/src/views/QuantumTP6/index.jsx
+++ b/src/views/QuantumTP6/index.jsx
@@ -9,7 +9,7 @@ import { withNavigation } from '../../vendor/utils/navigation';
 import Picker from '../../vendor/utils/navigation/Picker';
 import DashboardPage from '../../components/DashboardPage';
 import PerfherderGraphContainer from '../../containers/PerfherderGraphContainer';
-import { IvalidUrlMessage } from '../../components/criticalErrorMessage';
+import { InvalidUrlMessage } from '../../components/criticalErrorMessage';
 
 const styles = {
   body: {
@@ -64,7 +64,7 @@ class TP6 extends React.Component {
         </div>
       );
 
-    return <IvalidUrlMessage />;
+    return <InvalidUrlMessage />;
   }
 }
 

--- a/test/quantum/__snapshots__/index-64.test.jsx.snap
+++ b/test/quantum/__snapshots__/index-64.test.jsx.snap
@@ -428,7 +428,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -438,11 +438,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -510,7 +510,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -520,11 +520,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -558,7 +558,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -568,11 +568,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -606,7 +606,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -616,11 +616,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -654,7 +654,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -664,11 +664,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -702,7 +702,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -712,11 +712,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -750,7 +750,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -760,11 +760,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -798,7 +798,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -808,11 +808,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -846,7 +846,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -856,11 +856,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -894,7 +894,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -904,11 +904,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -942,7 +942,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -952,11 +952,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -990,7 +990,7 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
+              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
               role="progressbar"
               style={
                 Object {
@@ -1000,11 +1000,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-149"
+                className="MuiCircularProgress-svg-111"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
+                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
                   cx={44}
                   cy={44}
                   fill="none"

--- a/test/quantum/__snapshots__/index-64.test.jsx.snap
+++ b/test/quantum/__snapshots__/index-64.test.jsx.snap
@@ -428,19 +428,6 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
-            <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
@@ -523,19 +510,6 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
-            <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
@@ -583,19 +557,6 @@ exports[`renders correctly 1`] = `
               }
             }
           >
-            <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
             <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
@@ -645,19 +606,6 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
-            <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
@@ -705,19 +653,6 @@ exports[`renders correctly 1`] = `
               }
             }
           >
-            <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
             <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
@@ -767,19 +702,6 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
-            <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
@@ -827,19 +749,6 @@ exports[`renders correctly 1`] = `
               }
             }
           >
-            <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
             <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
@@ -889,19 +798,6 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
-            <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
@@ -949,19 +845,6 @@ exports[`renders correctly 1`] = `
               }
             }
           >
-            <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
             <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
@@ -1011,19 +894,6 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
-            <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
@@ -1072,19 +942,6 @@ exports[`renders correctly 1`] = `
             }
           >
             <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
-            <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
@@ -1132,19 +989,6 @@ exports[`renders correctly 1`] = `
               }
             }
           >
-            <div
-              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
-            >
-              <span
-                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "<p>Something went wrong, please try again later.</p>
-",
-                  }
-                }
-              />
-            </div>
             <div
               className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"

--- a/test/quantum/__snapshots__/index-64.test.jsx.snap
+++ b/test/quantum/__snapshots__/index-64.test.jsx.snap
@@ -421,14 +421,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -438,11 +451,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -503,14 +516,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -520,11 +546,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -551,14 +577,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -568,11 +607,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -599,14 +638,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -616,11 +668,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -647,14 +699,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -664,11 +729,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -695,14 +760,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -712,11 +790,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -743,14 +821,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -760,11 +851,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -791,14 +882,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -808,11 +912,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -839,14 +943,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -856,11 +973,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -887,14 +1004,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -904,11 +1034,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -935,14 +1065,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -952,11 +1095,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -983,14 +1126,27 @@ exports[`renders correctly 1`] = `
           <div
             style={
               Object {
-                "lineHeight": "8rem",
+                "lineHeight": "100%",
                 "textAlign": "center",
-                "width": "8rem",
+                "width": "100%",
               }
             }
           >
             <div
-              className="MuiCircularProgress-root-106 MuiCircularProgress-colorPrimary-109 MuiCircularProgress-indeterminate-108"
+              className="MuiPaper-root-116 MuiPaper-elevation2-120 MuiPaper-rounded-117 t-panel-106 t-paper-107 t-error-110 ChartJsWrapper-errorPanel-105"
+            >
+              <span
+                className="t-root-143 t-markdownContent-108 t-errorText-112 t-pad-109"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Something went wrong, please try again later.</p>
+",
+                  }
+                }
+              />
+            </div>
+            <div
+              className="MuiCircularProgress-root-144 MuiCircularProgress-colorPrimary-147 MuiCircularProgress-indeterminate-146"
               role="progressbar"
               style={
                 Object {
@@ -1000,11 +1156,11 @@ exports[`renders correctly 1`] = `
               }
             >
               <svg
-                className="MuiCircularProgress-svg-111"
+                className="MuiCircularProgress-svg-149"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  className="MuiCircularProgress-circle-112 MuiCircularProgress-circleIndeterminate-114"
+                  className="MuiCircularProgress-circle-150 MuiCircularProgress-circleIndeterminate-152"
                   cx={44}
                   cy={44}
                   fill="none"
@@ -1048,15 +1204,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1078,15 +1236,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1108,15 +1268,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1138,15 +1300,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1168,15 +1332,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1198,15 +1364,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1228,15 +1396,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1258,15 +1428,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1288,15 +1460,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1318,15 +1492,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1348,15 +1524,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1378,15 +1556,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1408,15 +1588,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1438,15 +1620,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1468,15 +1652,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1498,15 +1684,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1528,15 +1716,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1558,15 +1748,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1588,15 +1780,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1618,15 +1812,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1648,15 +1844,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1678,15 +1876,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1708,15 +1908,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1738,15 +1940,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1768,15 +1972,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1798,15 +2004,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1828,15 +2036,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1858,15 +2068,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1888,15 +2100,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1918,15 +2132,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1948,15 +2164,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1978,15 +2196,17 @@ exports[`renders correctly 1`] = `
               </a>
             </h3>
           </header>
-          <div
-            className="graph-subtitle"
-          />
-          <div
-            className="graph"
-          >
+          <div>
             <div
-              className="graph-legend"
+              className="graph-subtitle"
             />
+            <div
+              className="graph"
+            >
+              <div
+                className="graph-legend"
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fix for #83 
@sarah-clements I went with your suggestion using error panel to display error as I'm not comfortable with HOC yet I would try that v soon when I feel confident working with that. 

To test:
go to http://localhost:5000/quantum/64 and check for failed telemetry requests, an error message is displayed here. 

Disconnect from the internet, go to http://localhost:5000/quantum/tp6?bits=64 
You will see error msgs when there is no data. 

For this case, having the wrong parameter ( 323 instead of 32 of 64) 
https://health.graphics/quantum/323 

The code is written to handle this issue as 
if the user enters '32' then show data related to '32' bit else show '64' bit data no matter what value is entered. [See code](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/quantum/index.jsx#L36-L42)

So if the user enters 32 then it will render 32 bit data otherwise for any case it will throw 64 bit. 

Only this case is left: https://health.graphics/quantum/tp6?bits=63 
which I am figuring out to throw error its in process

Meanwhile please review the current PR. 