### PR TITLE
fix handle click over legend to hide/show series

### DIFF
--- a/src/utils/registerTooltip.jsx
+++ b/src/utils/registerTooltip.jsx
@@ -10,6 +10,10 @@ const handleOnClick = (_, items) => {
     // the current tooltip in view has a reference to the last active tooltip
     // eslint-disable-next-line prefer-destructuring
     Chart.lastClickedDataPoint = items[0]._chart.tooltip._lastActive[0];
+  } else {
+    // we need default handlers outside of a data point
+    // e.g. to hide/show series when legends are clicked
+    return Chart.defaults.global.onClick;
   }
 
   Chart.helpers.each(Chart.instances, chartItem => {


### PR DESCRIPTION
Fix #229 
@klahnakoski @armenzg 
I noticed that by default ChartJS shipped their charts with the ability to hide/show series, but somehow this was being blocked/changed in our project. After tracking down the issue, it was `registerTooltip.jsx`the culprit. I only added the case when the click event happened outside of a data point.

As you can see in [1], it looks nice. 

Now, I think we should change the minimum axes range, because in the Perfherder graphs, the data points are far from 0, and even after hiding some series, the plot doesn't look as good as it could be, but that's a different issue to solve :)

[1]
![ezgif-4-f270f71a420e](https://user-images.githubusercontent.com/4089035/53295920-4068a780-37cb-11e9-8a9e-be84e5376060.gif)

