### PR TITLE
add .editorconfig to tame windows ide

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+end_of_line = lf


### PR DESCRIPTION
@armenzg this is to command my ide to write the correct line endings and remove the very embarrassing `/* eslint-disable linebreak-style */`  Since this file is quite common in a repo, I hope it can be added to this one too (and maybe extended to include more rules).