### PR TITLE
Fix crash because of empty slots for series array

### DIFF
--- a/src/utils/perfherder/chartJs/getPerfherderData.js
+++ b/src/utils/perfherder/chartJs/getPerfherderData.js
@@ -41,7 +41,7 @@ const getPerfherderData = async series => {
       `can not get data for ${JSON.stringify(series[0].seriesConfig)}`
     );
 
-  return perfherderFormatter(newData);
+  return perfherderFormatter(newData.filter(Boolean));
 };
 
 export default getPerfherderData;


### PR DESCRIPTION
**Update:** This was an attempt to patch #382, but, as Kyle clearly mentioned:
> By filtering our missing series you change the index of each series, which then changes the color of the series.

it could give us more trouble, so the PR has been rejected.

----------------

@klahnakoski 
As you well mentioned in your issue, the real problem was getting empty slots in the series array. And the reason of that is the way [`getPerherderData`](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/utils/perfherder/chartJs/getPerfherderData.js) creates `newData`(which will become `series` once it gets formatted by `perfherderFormatter`): 

First it creates an array with empty slots taking the length of a primitive `series` ([L7](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/utils/perfherder/chartJs/getPerfherderData.js#L7)). Then it fills each slot with data obtained from `queryPerformanceData` ([L17](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/utils/perfherder/chartJs/getPerfherderData.js#L17)), but the problem is here, because `queryPerfomanceData` doesn't return data for all the series in all charts (_check [1] to see the series/charts affected and check [2] to read my deeper tracking analysis_).

Now I think that independently of `queryPerformanceData` returning data or not, `getPerherderData` **shouldn't return an array with empty slots**. That's the reason I decided to apply a fix here, which is removing such empty slots before returning `newData`(remember, it becomes `series`after being formatted). 

I also thought on changing the way `newData` is built, creating an empty array first, and pushing elements in it while being 'fetched', but because such creation is asynchronous, we would lose the original order of each series, which is visually important in charts labels. I'm a newbie with asynchronous functions but I think that would happen and it's the reason @armenzg built it that way.

**[1]** 

The charts (suites) being affected are:
"raptor-tp6m-google-geckoview", series Index 1 (one of two series are displayed)
"raptor-tp6m-wikipedia-geckoview", series Index 1 (one of two series are displayed)
"raptor-tp6m-youtube-geckoview", series Index 1 (one of two series are displayed)
"raptor-unity-webgl-geckoview", series Index 3 (four of five series are displayed)

**[2]** 

When I noticed that `queryPerformanceData` ([L17](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/utils/perfherder/chartJs/getPerfherderData.js#L17)) wasn't returning data from the cases in [1]. I tried to track down the problem. This is what I got (only affected series):

-\>  In `perf-goggles.js`, for some `seriesConfig`, because `parentSignatureInfo` produces an empty `parentInfo`, `queryPerfomanceData` returns an empty object ([L232](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/vendor/perf-goggles.js#L232))

-\>  In `parentSignatureInfo`, `signaturesForPlatformSuite(seriesConfig)` ([L201](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/vendor/perf-goggles.js#L201)) is empty.

-\>  In [`signaturesForPlatformSuite`](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/vendor/perf-goggles.js#L142), there's no signature in `allPlatformSignature` with `suite` property that matches `seriesConfig.suite`. For example you could analyze the case for the suite 'raptor-unity-webgl-geckoview' with:
```
const allPlatformSignatures = ...
+ if (seriesConfig.suite === 'raptor-unity-webgl-geckoview') {
+   console.log(allPlatformSignatures);
+ }
...
+console.log(filteredSignatures);
return filteredSignatures;
```
and see that one of the series (index 3) gets missed because [L153](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/vendor/perf-goggles.js#L153) was never satisfied.

And here is where I stopped, because I was already mentally tired (too late in the night).