### PR TITLE
fix null tooltip for series next to empty ones

### DIFF
--- a/src/utils/chartJs/CustomTooltip.jsx
+++ b/src/utils/chartJs/CustomTooltip.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import { missing } from '../../vendor/utils';
 
 const topAligned = {
   '--trans-y': 'var(--tip-size)',
@@ -95,12 +94,6 @@ class CustomTooltip extends React.Component {
     };
     const { index } = currPoint;
     const currSeries = series[currPoint.datasetIndex];
-
-    if (missing(currSeries)) {
-      // TODO: Add a warning here
-      return null;
-    }
-
     const higherOrLower = currSeries.meta.lower_is_better
       ? 'lower is better'
       : 'higher is better';

--- a/src/utils/perfherder/chartJs/perfherderFormatter.js
+++ b/src/utils/perfherder/chartJs/perfherderFormatter.js
@@ -31,7 +31,7 @@ const perfherderFormatter = series => {
   const newData = {
     data: { datasets: [] },
     // all the series beed to be send, in order to build a custom tooltip
-    options: generateInitialOptions(series),
+    options: generateInitialOptions(series.filter(Boolean)),
   };
 
   series.forEach(({ color, data, label, perfherderUrl }, index) => {


### PR DESCRIPTION
Fixes #382, improves #385 

@klahnakoski 

After #385, we are having the next problem: the tooltip of the series next to the empty slot is not being displayed. At the moment, only 'Pixel 2 (pgo)' (pink) in Unity WebGI is not being displayed ([check video](https://youtu.be/_EJMRBXyLFQ)).

So, what's happening here is `series` indexes in custom tooltip doesn't match completely with `tooltipModel.datasetIndex`, i.e. (for problematic charts) the data used for charts is clean already and doesn't have any empty slots but the one received in `series` is not cleaned and then the length and indexes (after the empty slot) won't match.

That's why we are getting crash problem now with the custom one and not before with default tooltip.

And the origin of that is a change I made at `perherderFormatter.js` [L24](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/utils/perfherder/chartJs/perfherderFormatter.js#L24). I passed `series`as a property inside `options` so I could use it inside `CustomTooltip`, but, again, `series`is not cleaned there from empty slots, and the data passed to charts was cleaned ([L38](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/src/utils/perfherder/chartJs/perfherderFormatter.js#L38)).

And well, the solution to our issues is just to get rid off those empty slots in the 'sibling' path to the cleaned data sent to charts (not in a parent one, as I did in the previous PR, cause that would give us color issues). More details in code comments.