### PR TITLE
Solve the backward button error

### DIFF
--- a/src/vendor/utils/navigation/index.jsx
+++ b/src/vendor/utils/navigation/index.jsx
@@ -49,6 +49,20 @@ function withNavigation(config) {
         this.updateHistory(change);
       };
 
+      componentDidUpdate(prevProps) {
+        const { search: thisSearch } = this.props.location;
+        const { search: prevSearch } = prevProps.location;
+
+        if (thisSearch !== prevSearch) {
+          // Update state based on current props
+          // eslint-disable-next-line react/no-did-update-set-state
+          this.setState(state => ({
+            ...state,
+            ...URL2Object(thisSearch),
+          }));
+        }
+      }
+
       updateHistory(change) {
         const { history, location } = this.props;
         const newState = { ...this.state, ...change };


### PR DESCRIPTION
This PR solves issue #314 
Add `// eslint-disable-next-line react/no-did-update-set-state` because without it, ESLint returns this error when commit:
`$ eslint --cache --ext mjs,jsx,js --format codeframe ".*.js" src test /workspace/firefox-health-dashboard/src/vendor/utils/navigation/index.jsx
			Do not use setState in componentDidUpdate (react/no-did-update-set-state) at src/vendor/utils/navigation/index.jsx:59:11:
			57 |           // Update state based on current props
			58 |
			> 59 |           this.setState(state => ({
			|           ^
			60 |             ...state,
			61 |             ...URL2Object(thisSearch),
			62 |           }));`

Another code version also has this error:
```
componentDidUpdate(prevProps) {
        const { search: thisSearch } = this.props.location;
        const { search: prevSearch } = prevProps.location;

        if (thisSearch !== prevSearch) {
          const params = URL2Object(thisSearch);
          this.setState(params);
        }
      }
```