### PR TITLE
Increase duration before warning when no new data for battery charts

### DIFF
--- a/src/power/index.jsx
+++ b/src/power/index.jsx
@@ -48,6 +48,7 @@ class Power extends React.Component {
                     },
                   }))
                   .toArray()}
+                missingDataInterval={10}
               />
             </Grid>
           ))}

--- a/src/utils/PerfherderGraphContainer.jsx
+++ b/src/utils/PerfherderGraphContainer.jsx
@@ -285,7 +285,7 @@ class PerfherderGraphContainer extends React.Component {
   }
 
   render() {
-    const { title } = this.props;
+    const { title, missingDataInterval } = this.props;
     const { jointUrl, standardOptions, isLoading } = this.state;
 
     return (
@@ -309,6 +309,7 @@ class PerfherderGraphContainer extends React.Component {
             style: { type: 'scatter' },
             isLoading,
             standardOptions,
+            missingDataInterval,
           }}
         />
       </div>
@@ -332,6 +333,7 @@ PerfherderGraphContainer.propTypes = {
   timeDomain: PropTypes.shape({
     min: PropTypes.instanceOf(Date).isRequired,
     max: PropTypes.instanceOf(Date).isRequired,
+    missingDataInterval: PropTypes.number,
   }),
 };
 

--- a/src/vendor/components/chartJs/ChartJsWrapper.jsx
+++ b/src/vendor/components/chartJs/ChartJsWrapper.jsx
@@ -59,7 +59,13 @@ class ChartJsWrapper extends React.Component {
   }
 
   render() {
-    const { classes, isLoading, title, chartHeight } = this.props;
+    const {
+      classes,
+      isLoading,
+      title,
+      chartHeight,
+      missingDataInterval,
+    } = this.props;
     const { cjsOptions, standardOptions } = this.state;
 
     if (isLoading) {
@@ -131,12 +137,12 @@ class ChartJsWrapper extends React.Component {
       );
       const daysDifference = Math.ceil(timeDifference / (1000 * 3600 * 24));
 
-      return daysDifference > 3;
+      return daysDifference > missingDataInterval;
     });
 
     if (allOldData) {
       const error = new Error(
-        'This item has been missing data for at least 3 days.'
+        `This item has been missing data for at least ${missingDataInterval} days.`
       );
 
       return (
@@ -182,6 +188,7 @@ ChartJsWrapper.propTypes = {
     ticksCallback: PropTypes.func,
     data: PropTypes.arrayOf(PropTypes.shape({})),
   }),
+  missingDataInterval: PropTypes.number,
 };
 
 ChartJsWrapper.defaultProps = {
@@ -189,6 +196,7 @@ ChartJsWrapper.defaultProps = {
   chartHeight: 80,
   spinnerSize: '100%',
   isLoading: false,
+  missingDataInterval: 3,
 };
 
 export default withStyles(styles)(ChartJsWrapper);


### PR DESCRIPTION
[Issue 470](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/issues/470)