### PR TITLE
Fixes #496 - Increase warning duration for perfherder charts on Android main page

### DIFF
--- a/src/android/index.jsx
+++ b/src/android/index.jsx
@@ -268,6 +268,7 @@ class Android extends Component {
                     },
                   },
                 ]}
+                missingDataInterval={10}
               />
             </Grid>
             <Grid item xs={6}>
@@ -337,6 +338,7 @@ class Android extends Component {
                     },
                   },
                 ]}
+                missingDataInterval={10}
               />
             </Grid>
           </Grid>

--- a/src/power/summary.jsx
+++ b/src/power/summary.jsx
@@ -39,6 +39,7 @@ class PowerSummary extends React.Component {
             },
           }))
           .toArray()}
+        missingDataInterval={10}
       />
     );
   }


### PR DESCRIPTION
@armenzg 
Chart should not show warning anymore
![](https://user-images.githubusercontent.com/122800/61367564-ce7d2180-a883-11e9-8147-11ea7149bc4f.png)