### PR TITLE
Issues 536 + 531 - Change media playback results to fenix

### DIFF
--- a/src/android/index.jsx
+++ b/src/android/index.jsx
@@ -194,7 +194,7 @@ class Android extends Component {
                 key="VP9"
                 bits={64}
                 encoding="VP9"
-                browserId="geckoview"
+                browserId="fenix"
               />
             </Grid>
             <Grid item xs={6} key="2">
@@ -202,7 +202,7 @@ class Android extends Component {
                 key="H264"
                 bits={64}
                 encoding="H264"
-                browserId="geckoview"
+                browserId="fenix"
               />
             </Grid>
           </Grid>

--- a/src/playback/config.js
+++ b/src/playback/config.js
@@ -124,7 +124,7 @@ const PLATFORMS = [
 const BROWSERS =[
   {id: "firefox", label:"Firefox", filter: {eq: {framework: 10, repo: 'mozilla-central', suite: ["raptor-youtube-playback-firefox-live"]}}},
   {id: "geckoview", label:"geckoview", filter: {eq: {framework: 10, repo: 'mozilla-central', suite: ["raptor-youtube-playback-geckoview-live"]}}},
-  {id: "fenix", label:"fenix", filter: {eq: {framework: 10, repo: 'fenix', suite: ["raptor-youtube-playback-fenix-live"]}}},
+  {id: "fenix", label:"Firefox Preview", filter: {eq: {framework: 10, repo: 'fenix', suite: ["raptor-youtube-playback-fenix-live"]}}},
 ];
 
 

--- a/src/playback/config.js
+++ b/src/playback/config.js
@@ -124,6 +124,7 @@ const PLATFORMS = [
 const BROWSERS =[
   {id: "firefox", label:"Firefox", filter: {eq: {framework: 10, repo: 'mozilla-central', suite: ["raptor-youtube-playback-firefox-live"]}}},
   {id: "geckoview", label:"geckoview", filter: {eq: {framework: 10, repo: 'mozilla-central', suite: ["raptor-youtube-playback-geckoview-live"]}}},
+  {id: "fenix", label:"fenix", filter: {eq: {framework: 10, repo: 'fenix', suite: ["raptor-youtube-playback-fenix-live"]}}},
 ];
 
 

--- a/src/playback/index.jsx
+++ b/src/playback/index.jsx
@@ -71,6 +71,7 @@ class Power extends React.Component {
                     },
                   }))
                   .toArray()}
+                missingDataInterval={browser === 'fenix' ? 7 : undefined}
               />
             </Grid>
           ))}


### PR DESCRIPTION
https://github.com/mozilla-frontend-infra/firefox-health-dashboard/issues/536 - Change media playback results to Firefox Preview
https://github.com/mozilla-frontend-infra/firefox-health-dashboard/issues/531 - Create media playback results page for Firefox Preview