### PR TITLE
add target blank for links

### DIFF
--- a/src/playback/summary.jsx
+++ b/src/playback/summary.jsx
@@ -231,6 +231,8 @@ class PlaybackSummary extends React.Component {
           <a
             href="https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/docs/about-media-playback.md#about---media-playback"
             title="more information"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             <HelpIcon />
           </a>


### PR DESCRIPTION
This PR fixes the [issue 577](https://github.com/mozilla-frontend-infra/firefox-health-dashboard/issues/577). I added `target="_blank"` for links in the summary component, so the documentation is opened on a new page, instead of redirecting.