### PR TITLE
fixed link on page  https://health.graphics/android

### DIFF
--- a/src/android/config.js
+++ b/src/android/config.js
@@ -11,7 +11,7 @@ import { HelpIcon } from '../utils/icons';
 const TARGET_NAME = "Fennec64 -20%";
 const REFERENCE_BROWSER = ['fennec64'];
 const REFERENCE_COLOR = '#45a1ff44';
-const GEOMEAN_DESCRIPTION = {title: "more information", url:"https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/docs/about-pageload#about---site-load-times", icon:HelpIcon};
+const GEOMEAN_DESCRIPTION = {title: "more information", url:"https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/docs/about-pageload.md#about---site-load-times", icon:HelpIcon};
 
 const tipStyles = {
     below: {


### PR DESCRIPTION
FIxes #582  -Fixed all the links to url pointing to https://github.com/mozilla-frontend-infra/firefox-health-dashboard/blob/master/docs/about-pageload.md#about---site-load-times