### PR TITLE
fix: broken link to neutrino.js description

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ git push --no-verify origin
 ## Neutrino and preset
 
 This project uses [Neutrino](https://github.com/neutrinojs/neutrino) and the
-[@neutrinojs/react](https://neutrino.js.org/packages/react/) preset. You can read about all features included in this preset in [here](https://github.com/neutrinojs/neutrino/blob/master/docs/packages/react/README.md#features).
+[@neutrinojs/react](https://neutrino.js.org/packages/react/) preset. You can read about all features included in this preset in [here](https://github.com/neutrinojs/neutrino/blob/master/packages/react/README.md#features).
 
 ## Attributions
 


### PR DESCRIPTION
I found that Neutrino "here" link is [broken](https://github.com/neutrinojs/neutrino/blob/master/docs/packages/react/README.md#features). I've changed it to [working one](https://github.com/neutrinojs/neutrino/blob/master/packages/react/README.md#features)