### PR TITLE
Reconfigure Renovate

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "schedule:earlyMondays"
+  ],
+  "minor": {
+    "enabled": false
+  },
+  "separateMinorPatch": true,
+  "patch": {
+    "automerge": true
+  },
+  "lockFileMaintenance": {
+    "automerge": true
+  }
+}


### PR DESCRIPTION
This configures renovate to:

* Schedule package updates early on Mondays
* Avoid taking minor packages
* Update patch releases independently from minor releases
* Auto merge patch releases silently if tests pass, otherwise, open PR
* Auto merge lock file maintenance if tests pass. Always open PR