### PR TITLE
charts locked to time domains

### DIFF
--- a/src/vendor/components/chartJs/utils.js
+++ b/src/vendor/components/chartJs/utils.js
@@ -108,7 +108,7 @@ const cjsGenerator = standardOptions => {
     return Data.fromConfig({ data, ...newRest });
   })();
   const xAxes = (() => {
-    const xDomain = Data.get(options, 'axis.x.domain');
+    const xDomain = Data.get(options, 'axis.x');
 
     if (xDomain) {
       return toArray(xDomain).map(x => {
@@ -343,15 +343,6 @@ const cjsGenerator = standardOptions => {
     };
   }
 
-  const labels = (() => {
-    const minX = standardOptions['axis.x.min'];
-    const maxX = standardOptions['axis.x.max'];
-    const singleDay = 24 * 60 * 60 * 1000;
-    const diffDays = Math.round(Math.abs((maxX - minX) / singleDay));
-
-    return [...Array(diffDays).keys()].map(data => minX.addDay(data));
-  })();
-
   const cjsOptions = {
     type: 'line', // dummy value to get legend to show
     options: {
@@ -369,7 +360,7 @@ const cjsGenerator = standardOptions => {
       },
       backgroundColor: 'rgb(255,0,0)',
     },
-    data: { datasets, labels },
+    data: { datasets },
   };
   if (ticksCallback) {
     cjsOptions.options.scales.yAxes[0].ticks.callback = ticksCallback;

--- a/src/vendor/components/chartJs/utils.js
+++ b/src/vendor/components/chartJs/utils.js
@@ -343,6 +343,15 @@ const cjsGenerator = standardOptions => {
     };
   }
 
+  const labels = (() => {
+    const minX = standardOptions['axis.x.min'];
+    const maxX = standardOptions['axis.x.max'];
+    const singleDay = 24 * 60 * 60 * 1000;
+    const diffDays = Math.round(Math.abs((maxX - minX) / singleDay));
+
+    return [...Array(diffDays).keys()].map(data => minX.addDay(data));
+  })();
+
   const cjsOptions = {
     type: 'line', // dummy value to get legend to show
     options: {
@@ -360,7 +369,7 @@ const cjsGenerator = standardOptions => {
       },
       backgroundColor: 'rgb(255,0,0)',
     },
-    data: { datasets },
+    data: { datasets, labels },
   };
   if (ticksCallback) {
     cjsOptions.options.scales.yAxes[0].ticks.callback = ticksCallback;


### PR DESCRIPTION
Here I have resolve issue #466 .
The charts have been locked to time domain by passing the labels as prop to the Chart component. Data points get distributed within the time range passed.