### PR TITLE
PR Ensure config files have link to repo for Playback #643

### DIFF
--- a/src/playback/config.js
+++ b/src/playback/config.js
@@ -109,12 +109,22 @@ const PLATFORMS = [
   },
 ];
 
+const MOZILLA_CENTRAL = {
+  name: "mozilla-central",
+  revisionURL: "https://hg.mozilla.org/mozilla-central/pushloghtml",
+}
+
+const FENIX = {
+  name: "fenix",
+  revisionURL: "https://github.com/mozilla-mobile/fenix/commit/",
+}
+
 
 const BROWSERS =[
-  {id: "firefox", label:"Firefox", title:"Firefox (Desktop)", format:"desktop", filter: {eq: {framework: 10, repo: 'mozilla-central', suite: ["raptor-youtube-playback-firefox-live"]}}},
-  {id: "chrome", label:"Chrome", title:"Chrome (Desktop)", format:"desktop", filter: {eq: {framework: 10, repo: 'mozilla-central', suite: ["raptor-youtube-playback-chrome-live"]}}},
-  {id: "geckoview", label:"geckoview", title:"Firefox (Android)", format:"mobile", filter: {eq: {framework: 10, repo: 'mozilla-central', suite: ["raptor-youtube-playback-geckoview-live"]}}},
-  {id: "fenix", label:"Firefox Preview", title:"Firefox Preview (Android)", format:"mobile", filter: {eq: {framework: 10, repo: 'fenix', suite: ["raptor-youtube-playback-fenix-live"]}}},
+  {id: "firefox", label:"Firefox", title:"Firefox (Desktop)", format:"desktop", filter: {eq: {framework: 10, repo: MOZILLA_CENTRAL, suite: ["raptor-youtube-playback-firefox-live"]}}},
+  {id: "chrome", label:"Chrome", title:"Chrome (Desktop)", format:"desktop", filter: {eq: {framework: 10, repo: MOZILLA_CENTRAL, suite: ["raptor-youtube-playback-chrome-live"]}}},
+  {id: "geckoview", label:"geckoview", title:"Firefox (Android)", format:"mobile", filter: {eq: {framework: 10, repo: MOZILLA_CENTRAL, suite: ["raptor-youtube-playback-geckoview-live"]}}},
+  {id: "fenix", label:"Firefox Preview", title:"Firefox Preview (Android)", format:"mobile", filter: {eq: {framework: 10, repo: FENIX, suite: ["raptor-youtube-playback-fenix-live"]}}},
 ];
 
 

--- a/src/utils/PerfherderGraphContainer.jsx
+++ b/src/utils/PerfherderGraphContainer.jsx
@@ -61,14 +61,12 @@ const tip = withStyles(tipStyles)(
       ? 'lower is better'
       : 'higher is better';
 
-    const revisionURL = record.meta.repo === 'mozilla-central'
-      ? `https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=${record.revision}`
-      : `https://github.com/mozilla-mobile/fenix/commit/${record.revision}`;
+    const revisionURL = URL(record.meta.repo.revisionURL, { changeset: record.revision });
 
     const jobURL = URL({
       path: 'https://treeherder.mozilla.org/#/jobs',
       query: {
-        repo: record.meta.repo,
+        repo: record.meta.repo.name,
         revision: record.revision,
         selectedJob: record.job_id,
         group_state: 'expanded',


### PR DESCRIPTION
  I have made changes allowing URL to be loaded from the config file. Please review the changes. 

 I set up a breakpoint on `const revisionURL = URL(record.meta.repo.revisionURL, {changeset: record.revision})` and loaded [https://localhost:5000/playback/details?platform=p2-aarch64&browser=fenix&encoding=VP9&past=week&ending=2020-01-07](https://localhost:5000/playback/details?platform=p2-aarch64&browser=fenix&encoding=VP9&past=week&ending=2020-01-07) but I was unable to inspect `record.meta`. It seems to me that the statement is not called for the particular URL or maybe I am doing something wrong It's my first time using debugging tools.
 