### PR TITLE
Fixing Linting Issues regarding config.json

### DIFF
--- a/src/nimbledroid/NimbledroidApiHandler.js
+++ b/src/nimbledroid/NimbledroidApiHandler.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { selectFrom } from '../vendor/vectors';
 import { fetchJson, URL } from '../vendor/requests';
-import SETTINGS from '../config';
+import SETTINGS from '../config.json';
 
 const ENDPOINT = URL({ path: [SETTINGS.backend, 'api/android/nimbledroid'] });
 const matchUrl = profileName => profileName.replace(

--- a/src/telemetry/graph.jsx
+++ b/src/telemetry/graph.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Log } from '../vendor/logs';
 import { fetchJson, URL } from '../vendor/requests';
-import SETTINGS from '../config';
+import SETTINGS from '../config.json';
 import { withErrorBoundary } from '../vendor/errors';
 
 class TelemetryContainer extends React.Component {

--- a/src/vendor/components/chartJs/utils.js
+++ b/src/vendor/components/chartJs/utils.js
@@ -1,4 +1,4 @@
-import SETTINGS from '../../../config';
+import SETTINGS from '../../../config.json';
 import {
   exists, isNumeric, missing, toArray, zip,
 } from '../../utils';


### PR DESCRIPTION
In three files namely **graph.jsx**, ### utils.js, and ### NimbledroidApiHandler.js
 
 The code written was

 `import SETTINGS from '../config';`

It is obviously correct but during linting, it generates an error which makes linting operation fails, because of no extension in config
![linting](https://user-images.githubusercontent.com/45850882/73185118-864c8f00-4143-11ea-9ed1-59654c841a91.png)

Fixed this issue across all three files 

 `import SETTINGS from '../config.json';`

