### PR TITLE
issue 455 - fixed the tooltip width

### DIFF
--- a/src/vendor/components/chartJs/CustomTooltip.jsx
+++ b/src/vendor/components/chartJs/CustomTooltip.jsx
@@ -26,6 +26,7 @@ const styles = {
     '--tip-size': '6px',
     position: 'absolute',
     padding: '6px',
+    width: '182px',
     background: 'var(--bg-color)',
     color: 'white',
     borderRadius: '4px',

--- a/src/vendor/components/chartJs/CustomTooltip.jsx
+++ b/src/vendor/components/chartJs/CustomTooltip.jsx
@@ -26,7 +26,7 @@ const styles = {
     '--tip-size': '6px',
     position: 'absolute',
     padding: '6px',
-    width: '182px',
+    'min-width': '182px',
     background: 'var(--bg-color)',
     color: 'white',
     borderRadius: '4px',


### PR DESCRIPTION
Hi this is my first ever PR.

I found out the 'squeezed tooltips' has a width (inherited) much less than other 'tooltips' which has a width of 182px.

By setting the width to 182px , now all tooltips behave the same on Firefox and Chrome
