### PR TITLE
Remove "-cold" from Browsertime test names

### DIFF
--- a/src/vendor/perfherder.js
+++ b/src/vendor/perfherder.js
@@ -130,6 +130,7 @@ const getFramework = async ({ repo, framework }) => {
             framework: meta.framework_id,
             application: meta.application,
             repo,
+            cold: Boolean(meta.extra_options) && meta.extra_options.includes('cold'),
             fission: Boolean(meta.extra_options) && meta.extra_options.includes('fission'),
           };
         })

--- a/src/windows/config.js
+++ b/src/windows/config.js
@@ -1936,303 +1936,411 @@ const TP6_SITES_DATA = {
 
     ['geckoview', 'cold', 'Tp6 mobile: Amazon', {
       eq: {
-        application: 'geckoview', suite: 'amazon-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'amazon', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Amazon Search', {
       eq: {
-        application: 'geckoview', suite: 'amazon-search-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'amazon-search', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: All Recipes', {
       eq: {
-        application: 'geckoview', suite: 'allrecipes-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'allrecipes', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: BBC', {
       eq: {
-        application: 'geckoview', suite: 'bbc-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'bbc', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Bing', {
       eq: {
-        application: 'geckoview', suite: 'bing-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'bing', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Bing Restaurants', {
       eq: {
-        application: 'geckoview', suite: 'bing-search-restaurants-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'bing-search-restaurants', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Booking', {
       eq: {
-        application: 'geckoview', suite: 'booking-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'booking', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: CNN', {
       eq: {
-        application: 'geckoview', suite: 'cnn-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'cnn', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: CNN AmpStories', {
       eq: {
-        application: 'geckoview', suite: 'cnn-ampstories-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'cnn-ampstories', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Kleinanzeigen', {
       eq: {
-        application: 'geckoview', suite: 'ebay-kleinanzeigen-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'ebay-kleinanzeigen', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Kleinanzeigen Search', {
       eq: {
-        application: 'geckoview', suite: 'ebay-kleinanzeigen-search-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'ebay-kleinanzeigen-search', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: ESPN', {
       eq: {
-        application: 'geckoview', suite: 'espn-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'espn', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Facebook', {
       eq: {
-        application: 'geckoview', suite: 'facebook-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'facebook', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Facebook Cristiano', {
       eq: {
-        application: 'geckoview', suite: 'facebook-cristiano-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'facebook-cristiano', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Google', {
       eq: {
-        application: 'geckoview', suite: 'google-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'google', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Google Maps', {
       eq: {
-        application: 'geckoview', suite: 'google-maps-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'google-maps', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Google Restaurants', {
       eq: {
-        application: 'geckoview', suite: 'google-search-restaurants-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'google-search-restaurants', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Instagram', {
       eq: {
-        application: 'geckoview', suite: 'instagram-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'instagram', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Imdb', {
       eq: {
-        application: 'geckoview', suite: 'imdb-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'imdb', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Jianshu', {
       eq: {
-        application: 'geckoview', suite: 'jianshu-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'jianshu', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Microsoft Support', {
       eq: {
-        application: 'geckoview', suite: 'microsoft-support-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'microsoft-support', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Reddit', {
       eq: {
-        application: 'geckoview', suite: 'reddit-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'reddit', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Stackoverflow', {
       eq: {
-        application: 'geckoview', suite: 'stackoverflow-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'stackoverflow', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Web.de', {
       eq: {
-        application: 'geckoview', suite: 'web-de-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'web-de', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: Wikipedia', {
       eq: {
-        application: 'geckoview', suite: 'wikipedia-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'wikipedia', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: YouTube', {
       eq: {
-        application: 'geckoview', suite: 'youtube-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'youtube', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'cold', 'Tp6 mobile: YouTube Watch', {
       eq: {
-        application: 'geckoview', suite: 'youtube-watch-cold', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'youtube-watch', cold: true, framework: 13, repo: 'mozilla-central',
       },
     }],
 
     ['geckoview', 'warm', 'Tp6 mobile: Amazon', {
       eq: {
-        application: 'geckoview', suite: 'amazon', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'amazon', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Amazon Search', {
       eq: {
-        application: 'geckoview', suite: 'amazon-search', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'amazon-search', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: All Recipes', {
       eq: {
-        application: 'geckoview', suite: 'allrecipes', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'allrecipes', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: BBC', {
       eq: {
-        application: 'geckoview', suite: 'bbc', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'bbc', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Bing', {
       eq: {
-        application: 'geckoview', suite: 'bing', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'bing', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Bing Restaurants', {
       eq: {
-        application: 'geckoview', suite: 'bing-search-restaurants', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'bing-search-restaurants', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Booking', {
       eq: {
-        application: 'geckoview', suite: 'booking', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'booking', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: CNN', {
       eq: {
-        application: 'geckoview', suite: 'cnn', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'cnn', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: CNN AmpStories', {
       eq: {
-        application: 'geckoview', suite: 'cnn-ampstories', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'cnn-ampstories', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Kleinanzeigen', {
       eq: {
-        application: 'geckoview', suite: 'ebay-kleinanzeigen', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'ebay-kleinanzeigen', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Kleinanzeigen Search', {
       eq: {
-        application: 'geckoview', suite: 'ebay-kleinanzeigen-search', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'ebay-kleinanzeigen-search', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: ESPN', {
       eq: {
-        application: 'geckoview', suite: 'espn', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'espn', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Facebook', {
       eq: {
-        application: 'geckoview', suite: 'facebook', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'facebook', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Facebook Cristiano', {
       eq: {
-        application: 'geckoview', suite: 'facebook-cristiano', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'facebook-cristiano', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Google', {
       eq: {
-        application: 'geckoview', suite: 'google', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'google', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Google Maps', {
       eq: {
-        application: 'geckoview', suite: 'google-maps', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'google-maps', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Google Restaurants', {
       eq: {
-        application: 'geckoview', suite: 'google-search-restaurants', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'google-search-restaurants', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Instagram', {
       eq: {
-        application: 'geckoview', suite: 'instagram', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'instagram', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Imdb', {
       eq: {
-        application: 'geckoview', suite: 'imdb', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'imdb', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Jianshu', {
       eq: {
-        application: 'geckoview', suite: 'jianshu', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'jianshu', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Microsoft Support', {
       eq: {
-        application: 'geckoview', suite: 'microsoft-support', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'microsoft-support', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Reddit', {
       eq: {
-        application: 'geckoview', suite: 'reddit', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'reddit', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Stackoverflow', {
       eq: {
-        application: 'geckoview', suite: 'stackoverflow', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'stackoverflow', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Web.de', {
       eq: {
-        application: 'geckoview', suite: 'web-de', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'web-de', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: Wikipedia', {
       eq: {
-        application: 'geckoview', suite: 'wikipedia', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'wikipedia', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: YouTube', {
       eq: {
-        application: 'geckoview', suite: 'youtube', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'youtube', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
     ['geckoview', 'warm', 'Tp6 mobile: YouTube Watch', {
       eq: {
-        application: 'geckoview', suite: 'youtube-watch', framework: 13, repo: 'mozilla-central',
+        application: 'geckoview', suite: 'youtube-watch', cold: false, framework: 13, repo: 'mozilla-central',
       },
     }],
 
-    ['fenix', 'cold', 'Tp6 mobile: Amazon', { eq: { suite: 'amazon-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Amazon Search', { eq: { suite: 'amazon-search-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: All Recipes', { eq: { suite: 'allrecipes-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: BBC', { eq: { suite: 'bbc-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Bing', { eq: { suite: 'bing-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Bing Restaurants', { eq: { suite: 'bing-search-restaurants-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Booking', { eq: { suite: 'booking-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: CNN', { eq: { suite: 'cnn-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: CNN AmpStories', { eq: { suite: 'cnn-ampstories-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Kleinanzeigen', { eq: { suite: 'ebay-kleinanzeigen-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Kleinanzeigen Search', { eq: { suite: 'ebay-kleinanzeigen-search-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: ESPN', { eq: { suite: 'espn-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Facebook', { eq: { suite: 'facebook-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Facebook Cristiano', { eq: { suite: 'facebook-cristiano-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Google', { eq: { suite: 'google-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Google Maps', { eq: { suite: 'google-maps-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Google Restaurants', { eq: { suite: 'google-search-restaurants-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Instagram', { eq: { suite: 'instagram-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Imdb', { eq: { suite: 'imdb-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Jianshu', { eq: { suite: 'jianshu-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Microsoft Support', { eq: { suite: 'microsoft-support-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Reddit', { eq: { suite: 'reddit-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Stackoverflow', { eq: { suite: 'stackoverflow-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Web.de', { eq: { suite: 'web-de-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: Wikipedia', { eq: { suite: 'wikipedia-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: YouTube', { eq: { suite: 'youtube-cold', framework: 13, repo: 'fenix' } }],
-    ['fenix', 'cold', 'Tp6 mobile: YouTube Watch', { eq: { suite: 'youtube-watch-cold', framework: 13, repo: 'fenix' } }],
+    ['fenix', 'cold', 'Tp6 mobile: Amazon', {
+      eq: {
+        suite: 'amazon', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Amazon Search', {
+      eq: {
+        suite: 'amazon-search', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: All Recipes', {
+      eq: {
+        suite: 'allrecipes', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: BBC', {
+      eq: {
+        suite: 'bbc', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Bing', {
+      eq: {
+        suite: 'bing', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Bing Restaurants', {
+      eq: {
+        suite: 'bing-search-restaurants', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Booking', {
+      eq: {
+        suite: 'booking', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: CNN', {
+      eq: {
+        suite: 'cnn', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: CNN AmpStories', {
+      eq: {
+        suite: 'cnn-ampstories', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Kleinanzeigen', {
+      eq: {
+        suite: 'ebay-kleinanzeigen', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Kleinanzeigen Search', {
+      eq: {
+        suite: 'ebay-kleinanzeigen-search', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: ESPN', {
+      eq: {
+        suite: 'espn', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Facebook', {
+      eq: {
+        suite: 'facebook', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Facebook Cristiano', {
+      eq: {
+        suite: 'facebook-cristiano', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Google', {
+      eq: {
+        suite: 'google', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Google Maps', {
+      eq: {
+        suite: 'google-maps', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Google Restaurants', {
+      eq: {
+        suite: 'google-search-restaurants', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Instagram', {
+      eq: {
+        suite: 'instagram', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Imdb', {
+      eq: {
+        suite: 'imdb', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Jianshu', {
+      eq: {
+        suite: 'jianshu', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Microsoft Support', {
+      eq: {
+        suite: 'microsoft-support', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Reddit', {
+      eq: {
+        suite: 'reddit', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Stackoverflow', {
+      eq: {
+        suite: 'stackoverflow', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Web.de', {
+      eq: {
+        suite: 'web-de', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: Wikipedia', {
+      eq: {
+        suite: 'wikipedia', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: YouTube', {
+      eq: {
+        suite: 'youtube', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
+    ['fenix', 'cold', 'Tp6 mobile: YouTube Watch', {
+      eq: {
+        suite: 'youtube-watch', cold: true, framework: 13, repo: 'fenix',
+      },
+    }],
 
     ['fennec68', 'cold', 'Tp6 mobile: Amazon', { eq: { suite: ['raptor-tp6m-amazon-fennec68-cold'], framework: 10, repo: 'mozilla-central' } }],
     ['fennec68', 'cold', 'Tp6 mobile: Amazon Search', { eq: { suite: ['raptor-tp6m-amazon-search-fennec68-cold'], framework: 10, repo: 'mozilla-central' } }],


### PR DESCRIPTION
This follows the change from [bug 1630675](https://bugzilla.mozilla.org/show_bug.cgi?id=1630675), where we remove '-cold' from the test name and instead include it in the extraOptions.